### PR TITLE
Add support for multiple LiDAR diagnostics.

### DIFF
--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -722,26 +722,29 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat)
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
 
-    if (lidar.second == nullptr) {
+    const auto & broadcast_code = lidar.first;
+    const auto & device_info = lidar.second;
+
+    if (device_info == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(lidar.first, "disconnected");
+      stat.add(broadcast_code, "disconnected");
       continue;
     }
 
-    if (lidar.second->state == kLidarStateInit) {
-      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
+    if (device_info->state == kLidarStateInit) {
+      stat.addf(broadcast_code, "%d%%", device_info->status.progress);
       continue;
     }
 
     TemperatureStatus status = static_cast<TemperatureStatus>(
-      lidar.second->status.status_code.lidar_error_code.temp_status);
+      device_info->status.status_code.lidar_error_code.temp_status);
     if (status == TemperatureStatus::HighOrLow) {
       level = DiagStatus::WARN;
     } else if (status == TemperatureStatus::ExtremelyHighOrLow) {
       level = DiagStatus::ERROR;
     }
 
-    stat.add(lidar.first, temperature_dict_.at(level));
+    stat.add(broadcast_code, temperature_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -766,26 +769,29 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat)
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
 
-    if (lidar.second == nullptr) {
+    const auto & broadcast_code = lidar.first;
+    const auto & device_info = lidar.second;
+
+    if (device_info == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(lidar.first, "disconnected");
+      stat.add(broadcast_code, "disconnected");
       continue;
     }
 
-    if (lidar.second->state == kLidarStateInit) {
-      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
+    if (device_info->state == kLidarStateInit) {
+      stat.addf(broadcast_code, "%d%%", device_info->status.progress);
       continue;
     }
 
     VoltageStatus status = static_cast<VoltageStatus>(
-      lidar.second->status.status_code.lidar_error_code.volt_status);
+      device_info->status.status_code.lidar_error_code.volt_status);
     if (status == VoltageStatus::High) {
       level = DiagStatus::WARN;
     } else if (status == VoltageStatus::ExtremelyHigh) {
       level = DiagStatus::ERROR;
     }
 
-    stat.add(lidar.first, motor_dict_.at(level));
+    stat.add(broadcast_code, motor_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -810,26 +816,29 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat)
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
 
-    if (lidar.second == nullptr) {
+    const auto & broadcast_code = lidar.first;
+    const auto & device_info = lidar.second;
+
+    if (device_info == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(lidar.first, "disconnected");
+      stat.add(broadcast_code, "disconnected");
       continue;
     }
 
-    if (lidar.second->state == kLidarStateInit) {
-      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
+    if (device_info->state == kLidarStateInit) {
+      stat.addf(broadcast_code, "%d%%", device_info->status.progress);
       continue;
     }
 
     MotorStatus status = static_cast<MotorStatus>(
-      lidar.second->status.status_code.lidar_error_code.motor_status);
+      device_info->status.status_code.lidar_error_code.motor_status);
     if (status == MotorStatus::Warning) {
       level = DiagStatus::WARN;
     } else if (status == MotorStatus::Error) {
       level = DiagStatus::ERROR;
     }
 
-    stat.add(lidar.first, motor_dict_.at(level));
+    stat.add(broadcast_code, motor_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -854,24 +863,27 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat)
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
 
-    if (lidar.second == nullptr) {
+    const auto & broadcast_code = lidar.first;
+    const auto & device_info = lidar.second;
+
+    if (device_info == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(lidar.first, "disconnected");
+      stat.add(broadcast_code, "disconnected");
       continue;
     }
 
-    if (lidar.second->state == kLidarStateInit) {
-      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
+    if (device_info->state == kLidarStateInit) {
+      stat.addf(broadcast_code, "%d%%", device_info->status.progress);
       continue;
     }
 
     DirtyStatus status = static_cast<DirtyStatus>(
-      lidar.second->status.status_code.lidar_error_code.dirty_warn);
+      device_info->status.status_code.lidar_error_code.dirty_warn);
     if (status == DirtyStatus::DirtyOrBlocked) {
       level = DiagStatus::WARN;
     }
 
-    stat.add(lidar.first, dirty_dict_.at(level));
+    stat.add(broadcast_code, dirty_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -896,24 +908,27 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper & stat)
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
 
-    if (lidar.second == nullptr) {
+    const auto & broadcast_code = lidar.first;
+    const auto & device_info = lidar.second;
+
+    if (device_info == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(lidar.first, "disconnected");
+      stat.add(broadcast_code, "disconnected");
       continue;
     }
 
-    if (lidar.second->state == kLidarStateInit) {
-      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
+    if (device_info->state == kLidarStateInit) {
+      stat.addf(broadcast_code, "%d%%", device_info->status.progress);
       continue;
     }
 
     FirmwareStatus status = static_cast<FirmwareStatus>(
-      lidar.second->status.status_code.lidar_error_code.firmware_err);
+      device_info->status.status_code.lidar_error_code.firmware_err);
     if (status == FirmwareStatus::Abnormal) {
       level = DiagStatus::ERROR;
     }
 
-    stat.add(lidar.first, firmware_dict_.at(level));
+    stat.add(broadcast_code, firmware_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -938,24 +953,27 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
 
-    if (lidar.second == nullptr) {
+    const auto & broadcast_code = lidar.first;
+    const auto & device_info = lidar.second;
+
+    if (device_info == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(lidar.first, "disconnected");
+      stat.add(broadcast_code, "disconnected");
       continue;
     }
 
-    if (lidar.second->state == kLidarStateInit) {
-      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
+    if (device_info->state == kLidarStateInit) {
+      stat.addf(broadcast_code, "%d%%", device_info->status.progress);
       continue;
     }
 
     PPSSignalStatus status = static_cast<PPSSignalStatus>(
-      lidar.second->status.status_code.lidar_error_code.pps_status);
+      device_info->status.status_code.lidar_error_code.pps_status);
     if (status == PPSSignalStatus::NoSignal) {
       level = DiagStatus::WARN;
     }
 
-    stat.add(lidar.first, pps_dict_.at(level));
+    stat.add(broadcast_code, pps_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -980,24 +998,27 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat)
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
 
-    if (lidar.second == nullptr) {
+    const auto & broadcast_code = lidar.first;
+    const auto & device_info = lidar.second;
+
+    if (device_info == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(lidar.first, "disconnected");
+      stat.add(broadcast_code, "disconnected");
       continue;
     }
 
-    if (lidar.second->state == kLidarStateInit) {
-      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
+    if (device_info->state == kLidarStateInit) {
+      stat.addf(broadcast_code, "%d%%", device_info->status.progress);
       continue;
     }
 
     ServiceLifeStatus status = static_cast<ServiceLifeStatus>(
-      lidar.second->status.status_code.lidar_error_code.device_status);
+      device_info->status.status_code.lidar_error_code.device_status);
     if (status == ServiceLifeStatus::Warning) {
       level = DiagStatus::WARN;
     }
 
-    stat.add(lidar.first, life_dict_.at(level));
+    stat.add(broadcast_code, life_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -1022,24 +1043,27 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat)
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
 
-    if (lidar.second == nullptr) {
+    const auto & broadcast_code = lidar.first;
+    const auto & device_info = lidar.second;
+
+    if (device_info == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(lidar.first, "disconnected");
+      stat.add(broadcast_code, "disconnected");
       continue;
     }
 
-    if (lidar.second->state == kLidarStateInit) {
-      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
+    if (device_info->state == kLidarStateInit) {
+      stat.addf(broadcast_code, "%d%%", device_info->status.progress);
       continue;
     }
 
     FanStatus status = static_cast<FanStatus>(
-      lidar.second->status.status_code.lidar_error_code.fan_status);
+      device_info->status.status_code.lidar_error_code.fan_status);
     if (status == FanStatus::Warning) {
       level = DiagStatus::WARN;
     }
 
-    stat.add(lidar.first, fan_dict_.at(level));
+    stat.add(broadcast_code, fan_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -1064,24 +1088,27 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
 
-    if (lidar.second == nullptr) {
+    const auto & broadcast_code = lidar.first;
+    const auto & device_info = lidar.second;
+
+    if (device_info == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(lidar.first, "disconnected");
+      stat.add(broadcast_code, "disconnected");
       continue;
     }
 
-    if (lidar.second->state == kLidarStateInit) {
-      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
+    if (device_info->state == kLidarStateInit) {
+      stat.addf(broadcast_code, "%d%%", device_info->status.progress);
       continue;
     }
 
     PTPSignalStatus status = static_cast<PTPSignalStatus>(
-      lidar.second->status.status_code.lidar_error_code.ptp_status);
+      device_info->status.status_code.lidar_error_code.ptp_status);
     if (status == PTPSignalStatus::NoSignal) {
       level = DiagStatus::WARN;
     }
 
-    stat.add(lidar.first, ptp_dict_.at(level));
+    stat.add(broadcast_code, ptp_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -1106,24 +1133,27 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat)
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
 
-    if (lidar.second == nullptr) {
+    const auto & broadcast_code = lidar.first;
+    const auto & device_info = lidar.second;
+
+    if (device_info == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(lidar.first, "disconnected");
+      stat.add(broadcast_code, "disconnected");
       continue;
     }
 
-    if (lidar.second->state == kLidarStateInit) {
-      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
+    if (device_info->state == kLidarStateInit) {
+      stat.addf(broadcast_code, "%d%%", device_info->status.progress);
       continue;
     }
 
     TimeSyncStatus status = static_cast<TimeSyncStatus>(
-      lidar.second->status.status_code.lidar_error_code.time_sync_status);
+      device_info->status.status_code.lidar_error_code.time_sync_status);
     if (status == TimeSyncStatus::Abnormal) {
       level = DiagStatus::WARN;
     }
 
-    stat.add(lidar.first, time_sync_dict_.at(level));
+    stat.add(broadcast_code, time_sync_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -29,9 +29,6 @@
 #include <math.h>
 #include <stdint.h>
 
-#define FMT_HEADER_ONLY
-#include "fmt/format.h"
-
 #include <rclcpp/rclcpp.hpp>
 #include <pcl_conversions/pcl_conversions.h>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -727,12 +724,12 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lidar.second == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(fmt::format("{}: status", lidar.first), "disconnected");
+      stat.add(lidar.first, "disconnected");
       continue;
     }
 
     if (lidar.second->state == kLidarStateInit) {
-      stat.addf(fmt::format("{}: progress", lidar.first), "%d%%", lidar.second->status.progress);
+      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
       continue;
     }
 
@@ -744,7 +741,7 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat)
       level = DiagStatus::ERROR;
     }
 
-    stat.add(fmt::format("{}: status", lidar.first), temperature_dict_.at(level));
+    stat.add(lidar.first, temperature_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -771,12 +768,12 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lidar.second == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(fmt::format("{}: status", lidar.first), "disconnected");
+      stat.add(lidar.first, "disconnected");
       continue;
     }
 
     if (lidar.second->state == kLidarStateInit) {
-      stat.addf(fmt::format("{}: progress", lidar.first), "%d%%", lidar.second->status.progress);
+      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
       continue;
     }
 
@@ -788,7 +785,7 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat)
       level = DiagStatus::ERROR;
     }
 
-    stat.add(fmt::format("{}: status", lidar.first), motor_dict_.at(level));
+    stat.add(lidar.first, motor_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -815,12 +812,12 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lidar.second == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(fmt::format("{}: status", lidar.first), "disconnected");
+      stat.add(lidar.first, "disconnected");
       continue;
     }
 
     if (lidar.second->state == kLidarStateInit) {
-      stat.addf(fmt::format("{}: progress", lidar.first), "%d%%", lidar.second->status.progress);
+      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
       continue;
     }
 
@@ -832,7 +829,7 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat)
       level = DiagStatus::ERROR;
     }
 
-    stat.add(fmt::format("{}: status", lidar.first), motor_dict_.at(level));
+    stat.add(lidar.first, motor_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -859,12 +856,12 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lidar.second == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(fmt::format("{}: status", lidar.first), "disconnected");
+      stat.add(lidar.first, "disconnected");
       continue;
     }
 
     if (lidar.second->state == kLidarStateInit) {
-      stat.addf(fmt::format("{}: progress", lidar.first), "%d%%", lidar.second->status.progress);
+      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
       continue;
     }
 
@@ -874,7 +871,7 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat)
       level = DiagStatus::WARN;
     }
 
-    stat.add(fmt::format("{}: status", lidar.first), dirty_dict_.at(level));
+    stat.add(lidar.first, dirty_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -901,12 +898,12 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lidar.second == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(fmt::format("{}: status", lidar.first), "disconnected");
+      stat.add(lidar.first, "disconnected");
       continue;
     }
 
     if (lidar.second->state == kLidarStateInit) {
-      stat.addf(fmt::format("{}: progress", lidar.first), "%d%%", lidar.second->status.progress);
+      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
       continue;
     }
 
@@ -916,7 +913,7 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper & stat)
       level = DiagStatus::ERROR;
     }
 
-    stat.add(fmt::format("{}: status", lidar.first), firmware_dict_.at(level));
+    stat.add(lidar.first, firmware_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -943,12 +940,12 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lidar.second == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(fmt::format("{}: status", lidar.first), "disconnected");
+      stat.add(lidar.first, "disconnected");
       continue;
     }
 
     if (lidar.second->state == kLidarStateInit) {
-      stat.addf(fmt::format("{}: progress", lidar.first), "%d%%", lidar.second->status.progress);
+      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
       continue;
     }
 
@@ -958,7 +955,7 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
       level = DiagStatus::WARN;
     }
 
-    stat.add(fmt::format("{}: status", lidar.first), pps_dict_.at(level));
+    stat.add(lidar.first, pps_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -985,12 +982,12 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lidar.second == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(fmt::format("{}: status", lidar.first), "disconnected");
+      stat.add(lidar.first, "disconnected");
       continue;
     }
 
     if (lidar.second->state == kLidarStateInit) {
-      stat.addf(fmt::format("{}: progress", lidar.first), "%d%%", lidar.second->status.progress);
+      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
       continue;
     }
 
@@ -1000,7 +997,7 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat)
       level = DiagStatus::WARN;
     }
 
-    stat.add(fmt::format("{}: status", lidar.first), life_dict_.at(level));
+    stat.add(lidar.first, life_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -1027,12 +1024,12 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lidar.second == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(fmt::format("{}: status", lidar.first), "disconnected");
+      stat.add(lidar.first, "disconnected");
       continue;
     }
 
     if (lidar.second->state == kLidarStateInit) {
-      stat.addf(fmt::format("{}: progress", lidar.first), "%d%%", lidar.second->status.progress);
+      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
       continue;
     }
 
@@ -1042,7 +1039,7 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat)
       level = DiagStatus::WARN;
     }
 
-    stat.add(fmt::format("{}: status", lidar.first), fan_dict_.at(level));
+    stat.add(lidar.first, fan_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -1069,12 +1066,12 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lidar.second == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(fmt::format("{}: status", lidar.first), "disconnected");
+      stat.add(lidar.first, "disconnected");
       continue;
     }
 
     if (lidar.second->state == kLidarStateInit) {
-      stat.addf(fmt::format("{}: progress", lidar.first), "%d%%", lidar.second->status.progress);
+      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
       continue;
     }
 
@@ -1084,7 +1081,7 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
       level = DiagStatus::WARN;
     }
 
-    stat.add(fmt::format("{}: status", lidar.first), ptp_dict_.at(level));
+    stat.add(lidar.first, ptp_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -1111,12 +1108,12 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lidar.second == nullptr) {
       error_str = "LiDAR disconnected";
-      stat.add(fmt::format("{}: status", lidar.first), "disconnected");
+      stat.add(lidar.first, "disconnected");
       continue;
     }
 
     if (lidar.second->state == kLidarStateInit) {
-      stat.addf(fmt::format("{}: progress", lidar.first), "%d%%", lidar.second->status.progress);
+      stat.addf(lidar.first, "%d%%", lidar.second->status.progress);
       continue;
     }
 
@@ -1126,7 +1123,7 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat)
       level = DiagStatus::WARN;
     }
 
-    stat.add(fmt::format("{}: status", lidar.first), time_sync_dict_.at(level));
+    stat.add(lidar.first, time_sync_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 

--- a/livox_ros2_driver/livox_ros2_driver/lds.h
+++ b/livox_ros2_driver/livox_ros2_driver/lds.h
@@ -35,6 +35,7 @@
 #include <vector>
 #include <mutex>
 #include <condition_variable>
+#include <map>
 
 #include "ldq.h"
 
@@ -493,6 +494,7 @@ class Lds {
   uint8_t lidar_count_;                 /**< Lidar access handle. */
   LidarDevice lidars_[kMaxSourceLidar]; /**< The index is the handle */
   Semaphore semaphore_;
+  std::map<std::string, DeviceInfo*> connected_lidars_;
 
  protected:
   uint32_t buffer_time_ms_; /**< Buffer time before data in queue is read */

--- a/livox_ros2_driver/livox_ros2_driver/lds_lidar.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lds_lidar.cpp
@@ -243,9 +243,11 @@ void LdsLidar::OnDeviceChange(const DeviceInfo *info, DeviceEvent type) {
     if (p_lidar->connect_state == kConnectStateOff) {
       p_lidar->connect_state = kConnectStateOn;
       p_lidar->info = *info;
+      g_lds_ldiar->connected_lidars_[p_lidar->info.broadcast_code] = &p_lidar->info;
     }
   } else if (type == kEventDisconnect) {
     printf("Lidar[%s] disconnect!\n", info->broadcast_code);
+    g_lds_ldiar->connected_lidars_[p_lidar->info.broadcast_code] = nullptr;
     ResetLidar(p_lidar, kSourceRawLidar);
   } else if (type == kEventStateChange) {
     p_lidar->info = *info;

--- a/livox_ros2_driver/package.xml
+++ b/livox_ros2_driver/package.xml
@@ -30,7 +30,6 @@
 
   <depend>git</depend>
   <depend>apr</depend>
-  <depend>fmt</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/livox_ros2_driver/package.xml
+++ b/livox_ros2_driver/package.xml
@@ -30,6 +30,7 @@
 
   <depend>git</depend>
   <depend>apr</depend>
+  <depend>fmt</depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
~~This is WIP PR. Please do not merge.~~
In this solution, a topic contains status of multiple LiDARs. ~~This should be discussed.~~
![image](https://user-images.githubusercontent.com/57388357/113838302-9b9e5e00-97c9-11eb-99a7-4451e64677cb.png)

The `diagnostic_updater` declares a parameter named as `period`.
So `rclcpp::exceptions::ParameterAlreadyDeclaredException` occurs when placing multiple `diagnostic_updater` in one ROS node.