### PR TITLE
Fix multiple LiDAR diagnostics

### DIFF
--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -224,12 +224,12 @@ uint32_t Lddc::PublishPointcloud2(LidarDataQueue *queue, uint32_t packet_num,
   if (kOutputToRos == output_type_) {
     publisher->publish(cloud);
   } else {
-#if 0    
+#if 0
     if (bag_) {
       bag_->write(p_publisher->getTopic(), rclcpp::Time(timestamp),
                   cloud);
     }
-#endif    
+#endif
   }
   if (!lidar->data_is_pubulished) {
     lidar->data_is_pubulished = true;
@@ -329,12 +329,12 @@ uint32_t Lddc::PublishPointcloudData(LidarDataQueue *queue, uint32_t packet_num,
   if (kOutputToRos == output_type_) {
     publisher->publish(cloud);
   } else {
-#if 0    
+#if 0
     if (bag_) {
       bag_->write(p_publisher->getTopic(), rclcpp::Time(timestamp),
                   cloud);
     }
-#endif    
+#endif
   }
   if (!lidar->data_is_pubulished) {
     lidar->data_is_pubulished = true;
@@ -453,16 +453,16 @@ uint32_t Lddc::PublishCustomPointcloud(LidarDataQueue *queue,
 
   rclcpp::Publisher<livox_interfaces::msg::CustomMsg>::SharedPtr publisher =
       std::dynamic_pointer_cast<rclcpp::Publisher
-      <livox_interfaces::msg::CustomMsg>>(GetCurrentPublisher(handle));  
+      <livox_interfaces::msg::CustomMsg>>(GetCurrentPublisher(handle));
   if (kOutputToRos == output_type_) {
     publisher->publish(livox_msg);
   } else {
-#if 0    
+#if 0
     if (bag_) {
       bag_->write(p_publisher->getTopic(), rclcpp::Time(timestamp),
           livox_msg);
     }
-#endif    
+#endif
   }
 
   if (!lidar->data_is_pubulished) {
@@ -510,12 +510,12 @@ uint32_t Lddc::PublishImuData(LidarDataQueue *queue, uint32_t packet_num,
   if (kOutputToRos == output_type_) {
     publisher->publish(imu_data);
   } else {
-#if 0    
+#if 0
     if (bag_) {
       bag_->write(p_publisher->getTopic(), rclcpp::Time(timestamp),
                   imu_data);
     }
-#endif    
+#endif
   }
   return published_packet;
 }

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -705,6 +705,7 @@ void Lddc::onDiagnosticsTimer()
   for (uint32_t i = 0; i < kMaxSourceLidar; ++i) {
     if (lds_->lidars_[i].handle != kMaxSourceLidar) ++lidar_count_;
   }
+  if (lidar_count_all_ < lidar_count_) lidar_count_all_ = lidar_count_;
   updater_.force_update();
 }
 
@@ -717,7 +718,7 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
   int whole_level = DiagStatus::OK;
 
-  for (uint8_t i = 0; i < lidar_count_; ++i) {
+  for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
     stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
@@ -751,7 +752,7 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
   int whole_level = DiagStatus::OK;
 
-  for (uint8_t i = 0; i < lidar_count_; ++i) {
+  for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
     stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
@@ -785,7 +786,7 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
   int whole_level = DiagStatus::OK;
 
-  for (uint8_t i = 0; i < lidar_count_; ++i) {
+  for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
     stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
@@ -819,7 +820,7 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
   int whole_level = DiagStatus::OK;
 
-  for (uint8_t i = 0; i < lidar_count_; ++i) {
+  for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
     stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
@@ -851,7 +852,7 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
   int whole_level = DiagStatus::OK;
 
-  for (uint8_t i = 0; i < lidar_count_; ++i) {
+  for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
     stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
@@ -883,7 +884,7 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
   int whole_level = DiagStatus::OK;
 
-  for (uint8_t i = 0; i < lidar_count_; ++i) {
+  for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
     stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
@@ -915,7 +916,7 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
   int whole_level = DiagStatus::OK;
 
-  for (uint8_t i = 0; i < lidar_count_; ++i) {
+  for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
     stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
@@ -947,7 +948,7 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
   int whole_level = DiagStatus::OK;
 
-  for (uint8_t i = 0; i < lidar_count_; ++i) {
+  for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
     stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
@@ -979,7 +980,7 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
   int whole_level = DiagStatus::OK;
 
-  for (uint8_t i = 0; i < lidar_count_; ++i) {
+  for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
     stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
@@ -1011,7 +1012,7 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
   int whole_level = DiagStatus::OK;
 
-  for (uint8_t i = 0; i < lidar_count_; ++i) {
+  for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
     stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -702,10 +702,16 @@ void Lddc::initializeDiagnostics()
 void Lddc::onDiagnosticsTimer()
 {
   lidar_count_ = 0;
+
   for (uint32_t i = 0; i < kMaxSourceLidar; ++i) {
     if (lds_->lidars_[i].handle != kMaxSourceLidar) ++lidar_count_;
   }
-  if (lidar_count_all_ < lidar_count_) lidar_count_all_ = lidar_count_;
+  if (lidar_count_all_ < lidar_count_) {
+    lidar_count_all_ = lidar_count_;
+    for (uint32_t i = 0; i < kMaxSourceLidar; ++i) {
+      strcpy(broadcast_code_list_[i], lds_->lidars_[i].info.broadcast_code);
+    }
+  }
   updater_.force_update();
 }
 
@@ -717,17 +723,19 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  bool connect_all = true;
 
   for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
-    stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
+    stat.add("broadcast code", broadcast_code_list_[i]);
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
-      if (lds_->lidars_[i].info.status.progress == 0){
+      if (lds_->lidars_[i].info.status.progress == 0) {
         level = DiagStatus::ERROR;
         whole_level = std::max(whole_level, level);
+        connect_all = false;
       }
       continue;
     }
@@ -744,7 +752,11 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, temperature_dict_.at(whole_level));
+  if (connect_all) {
+    stat.summary(whole_level, temperature_dict_.at(whole_level));
+  } else {
+    stat.summary(whole_level, "Disconnected");
+  }
 }
 
 void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -755,17 +767,19 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  bool connect_all = true;
 
   for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
-    stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
+    stat.add("broadcast code", broadcast_code_list_[i]);
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
-      if (lds_->lidars_[i].info.status.progress == 0){
+      if (lds_->lidars_[i].info.status.progress == 0) {
         level = DiagStatus::ERROR;
         whole_level = std::max(whole_level, level);
+        connect_all = false;
       }
       continue;
     }
@@ -782,7 +796,11 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, voltage_dict_.at(whole_level));
+  if (connect_all) {
+    stat.summary(whole_level, voltage_dict_.at(whole_level));
+  } else {
+    stat.summary(whole_level, "Disconnected");
+  }
 }
 
 void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -793,17 +811,19 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  bool connect_all = true;
 
   for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
-    stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
+    stat.add("broadcast code", broadcast_code_list_[i]);
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
-      if (lds_->lidars_[i].info.status.progress == 0){
+      if (lds_->lidars_[i].info.status.progress == 0) {
         level = DiagStatus::ERROR;
         whole_level = std::max(whole_level, level);
+        connect_all = false;
       }
       continue;
     }
@@ -820,7 +840,11 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, motor_dict_.at(whole_level));
+  if (connect_all) {
+    stat.summary(whole_level, motor_dict_.at(whole_level));
+  } else {
+    stat.summary(whole_level, "Disconnected");
+  }
 }
 
 void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -831,17 +855,19 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  bool connect_all = true;
 
   for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
-    stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
+    stat.add("broadcast code", broadcast_code_list_[i]);
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
-      if (lds_->lidars_[i].info.status.progress == 0){
+      if (lds_->lidars_[i].info.status.progress == 0) {
         level = DiagStatus::ERROR;
         whole_level = std::max(whole_level, level);
+        connect_all = false;
       }
       continue;
     }
@@ -856,7 +882,11 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, dirty_dict_.at(whole_level));
+  if (connect_all) {
+    stat.summary(whole_level, dirty_dict_.at(whole_level));
+  } else {
+    stat.summary(whole_level, "Disconnected");
+  }
 }
 
 void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -867,17 +897,19 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  bool connect_all = true;
 
   for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
-    stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
+    stat.add("broadcast code", broadcast_code_list_[i]);
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
-      if (lds_->lidars_[i].info.status.progress == 0){
+      if (lds_->lidars_[i].info.status.progress == 0) {
         level = DiagStatus::ERROR;
         whole_level = std::max(whole_level, level);
+        connect_all = false;
       }
       continue;
     }
@@ -892,7 +924,11 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, firmware_dict_.at(whole_level));
+  if (connect_all) {
+    stat.summary(whole_level, firmware_dict_.at(whole_level));
+  } else {
+    stat.summary(whole_level, "Disconnected");
+  }
 }
 
 void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -903,17 +939,19 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  bool connect_all = true;
 
   for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
-    stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
+    stat.add("broadcast code", broadcast_code_list_[i]);
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
-      if (lds_->lidars_[i].info.status.progress == 0){
+      if (lds_->lidars_[i].info.status.progress == 0) {
         level = DiagStatus::ERROR;
         whole_level = std::max(whole_level, level);
+        connect_all = false;
       }
       continue;
     }
@@ -927,8 +965,11 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
     stat.add("status", pps_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
-
-  stat.summary(whole_level, pps_dict_.at(whole_level));
+  if (connect_all) {
+    stat.summary(whole_level, pps_dict_.at(whole_level));
+  } else {
+    stat.summary(whole_level, "Disconnected");
+  }
 }
 
 void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -939,17 +980,19 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  bool connect_all = true;
 
   for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
-    stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
+    stat.add("broadcast code", broadcast_code_list_[i]);
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
-      if (lds_->lidars_[i].info.status.progress == 0){
+      if (lds_->lidars_[i].info.status.progress == 0) {
         level = DiagStatus::ERROR;
         whole_level = std::max(whole_level, level);
+        connect_all = false;
       }
       continue;
     }
@@ -964,7 +1007,11 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, life_dict_.at(whole_level));
+  if (connect_all) {
+    stat.summary(whole_level, life_dict_.at(whole_level));
+  } else {
+    stat.summary(whole_level, "Disconnected");
+  }
 }
 
 void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -975,17 +1022,19 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  bool connect_all = true;
 
   for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
-    stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
+    stat.add("broadcast code", broadcast_code_list_[i]);
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
-      if (lds_->lidars_[i].info.status.progress == 0){
+      if (lds_->lidars_[i].info.status.progress == 0) {
         level = DiagStatus::ERROR;
         whole_level = std::max(whole_level, level);
+        connect_all = false;
       }
       continue;
     }
@@ -1000,7 +1049,11 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, fan_dict_.at(whole_level));
+  if (connect_all) {
+    stat.summary(whole_level, fan_dict_.at(whole_level));
+  } else {
+    stat.summary(whole_level, "Disconnected");
+  }
 }
 
 void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -1011,17 +1064,19 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  bool connect_all = true;
 
   for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
-    stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
+    stat.add("broadcast code", broadcast_code_list_[i]);
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
-      if (lds_->lidars_[i].info.status.progress == 0){
+      if (lds_->lidars_[i].info.status.progress == 0) {
         level = DiagStatus::ERROR;
         whole_level = std::max(whole_level, level);
+        connect_all = false;
       }
       continue;
     }
@@ -1036,7 +1091,11 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, ptp_dict_.at(whole_level));
+  if (connect_all) {
+    stat.summary(whole_level, ptp_dict_.at(whole_level));
+  } else {
+    stat.summary(whole_level, "Disconnected");
+  }
 }
 
 void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -1047,17 +1106,19 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  bool connect_all = true;
 
   for (uint8_t i = 0; i < lidar_count_all_; ++i) {
     int level = DiagStatus::OK;
 
-    stat.add("broadcast code", lds_->lidars_[i].info.broadcast_code);
+    stat.add("broadcast code", broadcast_code_list_[i]);
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
-      if (lds_->lidars_[i].info.status.progress == 0){
+      if (lds_->lidars_[i].info.status.progress == 0) {
         level = DiagStatus::ERROR;
         whole_level = std::max(whole_level, level);
+        connect_all = false;
       }
       continue;
     }
@@ -1072,6 +1133,10 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, time_sync_dict_.at(whole_level));
+  if (connect_all) {
+    stat.summary(whole_level, time_sync_dict_.at(whole_level));
+  } else {
+    stat.summary(whole_level, "Disconnected");
+  }
 }
 }  // namespace livox_ros

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -725,6 +725,10 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
+      if (lds_->lidars_[i].info.status.progress == 0){
+        level = DiagStatus::ERROR;
+        whole_level = std::max(whole_level, level);
+      }
       continue;
     }
 
@@ -759,6 +763,10 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
+      if (lds_->lidars_[i].info.status.progress == 0){
+        level = DiagStatus::ERROR;
+        whole_level = std::max(whole_level, level);
+      }
       continue;
     }
 
@@ -793,6 +801,10 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
+      if (lds_->lidars_[i].info.status.progress == 0){
+        level = DiagStatus::ERROR;
+        whole_level = std::max(whole_level, level);
+      }
       continue;
     }
 
@@ -827,6 +839,10 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
+      if (lds_->lidars_[i].info.status.progress == 0){
+        level = DiagStatus::ERROR;
+        whole_level = std::max(whole_level, level);
+      }
       continue;
     }
 
@@ -859,6 +875,10 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
+      if (lds_->lidars_[i].info.status.progress == 0){
+        level = DiagStatus::ERROR;
+        whole_level = std::max(whole_level, level);
+      }
       continue;
     }
 
@@ -891,6 +911,10 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
+      if (lds_->lidars_[i].info.status.progress == 0){
+        level = DiagStatus::ERROR;
+        whole_level = std::max(whole_level, level);
+      }
       continue;
     }
 
@@ -923,6 +947,10 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
+      if (lds_->lidars_[i].info.status.progress == 0){
+        level = DiagStatus::ERROR;
+        whole_level = std::max(whole_level, level);
+      }
       continue;
     }
 
@@ -955,6 +983,10 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
+      if (lds_->lidars_[i].info.status.progress == 0){
+        level = DiagStatus::ERROR;
+        whole_level = std::max(whole_level, level);
+      }
       continue;
     }
 
@@ -987,6 +1019,10 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
+      if (lds_->lidars_[i].info.status.progress == 0){
+        level = DiagStatus::ERROR;
+        whole_level = std::max(whole_level, level);
+      }
       continue;
     }
 
@@ -1019,6 +1055,10 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
     if (lds_->lidars_[i].info.state == kLidarStateInit) {
       stat.addf("progress", "%d%%", lds_->lidars_[i].info.status.progress);
+      if (lds_->lidars_[i].info.status.progress == 0){
+        level = DiagStatus::ERROR;
+        whole_level = std::max(whole_level, level);
+      }
       continue;
     }
 

--- a/livox_ros2_driver/livox_ros2_driver/lddc.h
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.h
@@ -132,6 +132,7 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
   diagnostic_updater::Updater updater_;
   uint8_t lidar_count_;
+  uint8_t lidar_count_all_ = 0;
 
   const std::map<int, const char *> temperature_dict_ = {
     {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "High or Low"}, {DiagStatus::ERROR, "Extremely High or Extremely Low"}};

--- a/livox_ros2_driver/livox_ros2_driver/lddc.h
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.h
@@ -134,6 +134,8 @@ private:
   uint8_t lidar_count_;
   uint8_t lidar_count_all_ = 0;
 
+  std::vector<char[16]> broadcast_code_list_{std::vector<char[16]>(kMaxSourceLidar)};
+
   const std::map<int, const char *> temperature_dict_ = {
     {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "High or Low"}, {DiagStatus::ERROR, "Extremely High or Extremely Low"}};
 


### PR DESCRIPTION
This is a PR for soliving the problem in relation to #4 that the broadcast code of the remaining lidar is not displayed in diag such as fan_state when one lidar is pulled out.

![Screenshot from 2021-04-23 18-07-29](https://user-images.githubusercontent.com/39142679/115850299-b414a680-a460-11eb-8250-c9bc172a704d.png)
![Screenshot from 2021-04-23 18-07-54](https://user-images.githubusercontent.com/39142679/115850312-b545d380-a460-11eb-8740-61c229c03d0c.png)
![Screenshot from 2021-04-23 18-07-42](https://user-images.githubusercontent.com/39142679/115850309-b545d380-a460-11eb-8951-e730435987e2.png)