### PR TITLE
Fix many diag error when disconnected

### DIFF
--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -721,7 +721,6 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
-  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -751,12 +750,7 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  if (!error_str.empty()) {
-    stat.summary(DiagStatus::ERROR, error_str);
-  }
-  else {
-    stat.summary(whole_level, temperature_dict_.at(whole_level));
-  }
+  stat.summary(whole_level, temperature_dict_.at(whole_level));
 }
 
 void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -767,7 +761,6 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
-  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -797,12 +790,7 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  if (!error_str.empty()) {
-    stat.summary(DiagStatus::ERROR, error_str);
-  }
-  else {
-    stat.summary(whole_level, voltage_dict_.at(whole_level));
-  }
+  stat.summary(whole_level, voltage_dict_.at(whole_level));
 }
 
 void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -813,7 +801,6 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
-  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -843,12 +830,7 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  if (!error_str.empty()) {
-    stat.summary(DiagStatus::ERROR, error_str);
-  }
-  else {
-    stat.summary(whole_level, motor_dict_.at(whole_level));
-  }
+  stat.summary(whole_level, motor_dict_.at(whole_level));
 }
 
 void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -859,7 +841,6 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
-  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -887,12 +868,7 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  if (!error_str.empty()) {
-    stat.summary(DiagStatus::ERROR, error_str);
-  }
-  else {
-    stat.summary(whole_level, dirty_dict_.at(whole_level));
-  }
+  stat.summary(whole_level, dirty_dict_.at(whole_level));
 }
 
 void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -903,7 +879,6 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
-  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -931,12 +906,7 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  if (!error_str.empty()) {
-    stat.summary(DiagStatus::ERROR, error_str);
-  }
-  else {
-    stat.summary(whole_level, firmware_dict_.at(whole_level));
-  }
+  stat.summary(whole_level, firmware_dict_.at(whole_level));
 }
 
 void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -947,7 +917,6 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
-  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -975,12 +944,7 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  if (!error_str.empty()) {
-    stat.summary(DiagStatus::ERROR, error_str);
-  }
-  else {
-    stat.summary(whole_level, pps_dict_.at(whole_level));
-  }
+  stat.summary(whole_level, pps_dict_.at(whole_level));
 }
 
 void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -991,7 +955,6 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
-  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -1019,12 +982,7 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  if (!error_str.empty()) {
-    stat.summary(DiagStatus::ERROR, error_str);
-  }
-  else {
-    stat.summary(whole_level, life_dict_.at(whole_level));
-  }
+  stat.summary(whole_level, life_dict_.at(whole_level));
 }
 
 void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -1035,7 +993,6 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
-  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -1063,12 +1020,7 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  if (!error_str.empty()) {
-    stat.summary(DiagStatus::ERROR, error_str);
-  }
-  else {
-    stat.summary(whole_level, fan_dict_.at(whole_level));
-  }
+  stat.summary(whole_level, fan_dict_.at(whole_level));
 }
 
 void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -1079,7 +1031,6 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
-  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -1107,12 +1058,7 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  if (!error_str.empty()) {
-    stat.summary(DiagStatus::ERROR, error_str);
-  }
-  else {
-    stat.summary(whole_level, ptp_dict_.at(whole_level));
-  }
+  stat.summary(whole_level, ptp_dict_.at(whole_level));
 }
 
 void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -1123,7 +1069,6 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
-  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -1151,12 +1096,7 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
-  if (!error_str.empty()) {
-    stat.summary(DiagStatus::ERROR, error_str);
-  }
-  else {
-    stat.summary(whole_level, time_sync_dict_.at(whole_level));
-  }
+  stat.summary(whole_level, time_sync_dict_.at(whole_level));
 }
 
 void Lddc::checkConnection(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -1165,12 +1105,9 @@ void Lddc::checkConnection(diagnostic_updater::DiagnosticStatusWrapper & stat)
     stat.summary(DiagStatus::WARN, "No LiDARs Connected");
     return;
   }
-
-  int whole_level = DiagStatus::OK;
   std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
-    int level = DiagStatus::OK;
 
     const auto & broadcast_code = lidar.first;
     const auto & device_info = lidar.second;
@@ -1186,15 +1123,14 @@ void Lddc::checkConnection(diagnostic_updater::DiagnosticStatusWrapper & stat)
       continue;
     }
 
-    stat.add(broadcast_code, connection_dict_.at(level));
-    whole_level = std::max(whole_level, level);
+    stat.add(broadcast_code, "OK");
   }
 
   if (!error_str.empty()) {
     stat.summary(DiagStatus::ERROR, error_str);
   }
   else {
-    stat.summary(whole_level, connection_dict_.at(whole_level));
+    stat.summary(DiagStatus::OK, "OK");
   }
 }
 }  // namespace livox_ros

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -694,7 +694,7 @@ void Lddc::initializeDiagnostics()
   updater_.add("livox_fan_status", this, &Lddc::checkFan);
   updater_.add("livox_ptp_signal", this, &Lddc::checkPTPSignal);
   updater_.add("livox_time_sync", this, &Lddc::checkTimeSync);
-  updater_.add("livox_connect", this, &Lddc::checkConnect);
+  updater_.add("livox_connection", this, &Lddc::checkConnection);
   updater_.setHardwareID("livox");
 
   auto on_timer = std::bind(&Lddc::onDiagnosticsTimer, this);
@@ -1159,7 +1159,7 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 }
 
-void Lddc::checkConnect(diagnostic_updater::DiagnosticStatusWrapper & stat)
+void Lddc::checkConnection(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   if (lidar_count_ == 0) {
     stat.summary(DiagStatus::WARN, "No LiDARs Connected");
@@ -1186,7 +1186,7 @@ void Lddc::checkConnect(diagnostic_updater::DiagnosticStatusWrapper & stat)
       continue;
     }
 
-    stat.add(broadcast_code, connect_dict_.at(level));
+    stat.add(broadcast_code, connection_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -1194,7 +1194,7 @@ void Lddc::checkConnect(diagnostic_updater::DiagnosticStatusWrapper & stat)
     stat.summary(DiagStatus::ERROR, error_str);
   }
   else {
-    stat.summary(whole_level, connect_dict_.at(whole_level));
+    stat.summary(whole_level, connection_dict_.at(whole_level));
   }
 }
 }  // namespace livox_ros

--- a/livox_ros2_driver/livox_ros2_driver/lddc.h
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.h
@@ -113,7 +113,7 @@ private:
   void checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat);
   void checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat);
   void checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat);
-  void checkConnect(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  void checkConnection(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
   uint8_t transfer_format_;
   uint8_t use_multi_topic_;
@@ -164,7 +164,7 @@ private:
   const std::map<int, const char *> time_sync_dict_ = {
     {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "System time synchronization is abnormal"}, {DiagStatus::ERROR, "unused"}};
 
-  const std::map<int, const char *> connect_dict_ = {
+  const std::map<int, const char *> connection_dict_ = {
     {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "disconnected"}, {DiagStatus::ERROR, "disconnected"}};
 
 };

--- a/livox_ros2_driver/livox_ros2_driver/lddc.h
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.h
@@ -164,9 +164,6 @@ private:
   const std::map<int, const char *> time_sync_dict_ = {
     {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "System time synchronization is abnormal"}, {DiagStatus::ERROR, "unused"}};
 
-  const std::map<int, const char *> connection_dict_ = {
-    {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "disconnected"}, {DiagStatus::ERROR, "disconnected"}};
-
 };
 
 }  // namespace livox_ros

--- a/livox_ros2_driver/livox_ros2_driver/lddc.h
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.h
@@ -113,6 +113,7 @@ private:
   void checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat);
   void checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat);
   void checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  void checkConnect(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
   uint8_t transfer_format_;
   uint8_t use_multi_topic_;
@@ -162,6 +163,9 @@ private:
 
   const std::map<int, const char *> time_sync_dict_ = {
     {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "System time synchronization is abnormal"}, {DiagStatus::ERROR, "unused"}};
+
+  const std::map<int, const char *> connect_dict_ = {
+    {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "disconnected"}, {DiagStatus::ERROR, "disconnected"}};
 
 };
 


### PR DESCRIPTION
With this PR, when one lidar is disconnected, only `livox_connect` diagnostics become error instead of multiple kind of diagnostics.

- all lidars are connected

![Screenshot from 2021-05-27 11-17-56](https://user-images.githubusercontent.com/39142679/119756169-1e948880-bede-11eb-8f49-e3429cc636c6.png)

- one lidar is disconnected
  -  only `livox_connect` diagnostics become Errors
![Screenshot from 2021-05-27 11-18-07](https://user-images.githubusercontent.com/39142679/119756200-2b18e100-bede-11eb-81f0-86de232bc097.png)
  -  other diagnostics remain OK
![Screenshot from 2021-05-27 11-18-11](https://user-images.githubusercontent.com/39142679/119756203-2bb17780-bede-11eb-8991-9dec9374a7a2.png)
