### PR TITLE
Add use_ros_time

### DIFF
--- a/livox_ros2_driver/livox_ros2_driver/lds.h
+++ b/livox_ros2_driver/livox_ros2_driver/lds.h
@@ -189,6 +189,7 @@ typedef struct {
   char broadcast_code[16];
   bool enable_connect;
   bool enable_fan;
+  bool use_ros_time;
   uint32_t return_mode;
   uint32_t coordinate;
   uint32_t imu_rate;

--- a/livox_ros2_driver/livox_ros2_driver/lds_lidar.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lds_lidar.cpp
@@ -684,6 +684,9 @@ int LdsLidar::ParseConfigFile(const char *pathname) {
           if (object.HasMember("enable_fan") && object["enable_fan"].IsBool()) {
             config.enable_fan = object["enable_fan"].GetBool();
           }
+          if (object.HasMember("use_ros_time") && object["use_ros_time"].IsBool()) {
+            config.use_ros_time = object["use_ros_time"].GetBool();
+          }
           if (object.HasMember("return_mode") &&
               object["return_mode"].IsInt()) {
             config.return_mode = object["return_mode"].GetInt();
@@ -785,6 +788,7 @@ int LdsLidar::GetRawConfig(const char *broadcast_code, UserRawConfig &config) {
     if (strncmp(ite_config.broadcast_code, broadcast_code,
                 kBroadcastCodeSize) == 0) {
       config.enable_fan = ite_config.enable_fan;
+      config.use_ros_time = ite_config.use_ros_time;
       config.return_mode = ite_config.return_mode;
       config.coordinate = ite_config.coordinate;
       config.imu_rate = ite_config.imu_rate;


### PR DESCRIPTION
If `use_ros_time` is true, use the current time at publish for the cloud and imu stamps.
In this PR, it is necessary to add `use_ros_time` to `lidar_livox_config.json`.