### PR TITLE
Find error devices

### DIFF
--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -690,7 +690,6 @@ void Lddc::initializeDiagnostics()
 {
   using std::chrono_literals::operator""s;
 
-  // bool check_pps_signal =
   check_pps_signal_ =
     cur_node_->declare_parameter("check_pps_signal", false);
 

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -811,7 +811,7 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     TemperatureStatus status = static_cast<TemperatureStatus>(
-        device_info->status.status_code.lidar_error_code.temp_status);
+      device_info->status.status_code.lidar_error_code.temp_status);
     if (status == TemperatureStatus::HighOrLow) {
       level = DiagStatus::WARN;
     } else if (status == TemperatureStatus::ExtremelyHighOrLow) {
@@ -841,7 +841,7 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     VoltageStatus status = static_cast<VoltageStatus>(
-        device_info->status.status_code.lidar_error_code.volt_status);
+      device_info->status.status_code.lidar_error_code.volt_status);
     if (status == VoltageStatus::High) {
       level = DiagStatus::WARN;
     } else if (status == VoltageStatus::ExtremelyHigh) {
@@ -871,7 +871,7 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     MotorStatus status = static_cast<MotorStatus>(
-        device_info->status.status_code.lidar_error_code.motor_status);
+      device_info->status.status_code.lidar_error_code.motor_status);
     if (status == MotorStatus::Warning) {
       level = DiagStatus::WARN;
     } else if (status == MotorStatus::Error) {
@@ -901,7 +901,7 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     DirtyStatus status = static_cast<DirtyStatus>(
-        device_info->status.status_code.lidar_error_code.dirty_warn);
+      device_info->status.status_code.lidar_error_code.dirty_warn);
     if (status == DirtyStatus::DirtyOrBlocked) {
       level = DiagStatus::WARN;
     }
@@ -929,7 +929,7 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     FirmwareStatus status = static_cast<FirmwareStatus>(
-        device_info->status.status_code.lidar_error_code.firmware_err);
+      device_info->status.status_code.lidar_error_code.firmware_err);
     if (status == FirmwareStatus::Abnormal) {
       level = DiagStatus::ERROR;
     }
@@ -957,7 +957,7 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     PPSSignalStatus status = static_cast<PPSSignalStatus>(
-        device_info->status.status_code.lidar_error_code.pps_status);
+      device_info->status.status_code.lidar_error_code.pps_status);
     if (status == PPSSignalStatus::NoSignal) {
       level = DiagStatus::WARN;
     }
@@ -985,7 +985,7 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     ServiceLifeStatus status = static_cast<ServiceLifeStatus>(
-        device_info->status.status_code.lidar_error_code.device_status);
+      device_info->status.status_code.lidar_error_code.device_status);
     if (status == ServiceLifeStatus::Warning) {
       level = DiagStatus::WARN;
     }
@@ -1013,7 +1013,7 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     FanStatus status = static_cast<FanStatus>(
-        device_info->status.status_code.lidar_error_code.fan_status);
+      device_info->status.status_code.lidar_error_code.fan_status);
     if (status == FanStatus::Warning) {
       level = DiagStatus::WARN;
     }
@@ -1040,7 +1040,7 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper &stat, con
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     PTPSignalStatus status = static_cast<PTPSignalStatus>(
-        device_info->status.status_code.lidar_error_code.ptp_status);
+      device_info->status.status_code.lidar_error_code.ptp_status);
     if (status == PTPSignalStatus::NoSignal) {
       level = DiagStatus::WARN;
     }
@@ -1068,7 +1068,7 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     TimeSyncStatus status = static_cast<TimeSyncStatus>(
-        device_info->status.status_code.lidar_error_code.time_sync_status);
+      device_info->status.status_code.lidar_error_code.time_sync_status);
     if (status == TimeSyncStatus::Abnormal) {
       level = DiagStatus::WARN;
     }

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -729,6 +729,7 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -754,11 +755,16 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat)
       level = DiagStatus::ERROR;
     }
 
+    if (level != DiagStatus::OK) {
+      if (error_str != "") error_str += ", ";
+      error_str += broadcast_code + ": " + temperature_dict_.at(level);
+    }
+
     stat.add(broadcast_code, temperature_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, temperature_dict_.at(whole_level));
+  stat.summary(whole_level, error_str);
 }
 
 void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -769,6 +775,7 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -794,11 +801,16 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat)
       level = DiagStatus::ERROR;
     }
 
-    stat.add(broadcast_code, motor_dict_.at(level));
+    if (level != DiagStatus::OK) {
+      if (error_str != "") error_str += ", ";
+      error_str += broadcast_code + ": " + voltage_dict_.at(level);
+    }
+
+    stat.add(broadcast_code, voltage_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, voltage_dict_.at(whole_level));
+  stat.summary(whole_level, error_str);
 }
 
 void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -809,6 +821,7 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -834,11 +847,16 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat)
       level = DiagStatus::ERROR;
     }
 
+    if (level != DiagStatus::OK) {
+      if (error_str != "") error_str += ", ";
+      error_str += broadcast_code + ": " + motor_dict_.at(level);
+    }
+
     stat.add(broadcast_code, motor_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, motor_dict_.at(whole_level));
+  stat.summary(whole_level, error_str);
 }
 
 void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -849,6 +867,7 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -872,11 +891,16 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat)
       level = DiagStatus::WARN;
     }
 
+    if (level != DiagStatus::OK) {
+      if (error_str != "") error_str += ", ";
+      error_str += broadcast_code + ": " + dirty_dict_.at(level);
+    }
+
     stat.add(broadcast_code, dirty_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, dirty_dict_.at(whole_level));
+  stat.summary(whole_level, error_str);
 }
 
 void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -887,6 +911,7 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -909,12 +934,16 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper & stat)
     if (status == FirmwareStatus::Abnormal) {
       level = DiagStatus::ERROR;
     }
+    if (level != DiagStatus::OK) {
+      if (error_str != "") error_str += ", ";
+      error_str += broadcast_code + ": " + firmware_dict_.at(level);
+    }
 
     stat.add(broadcast_code, firmware_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, firmware_dict_.at(whole_level));
+  stat.summary(whole_level, error_str);
 }
 
 void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -925,6 +954,7 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -947,12 +977,16 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
     if (status == PPSSignalStatus::NoSignal) {
       level = DiagStatus::WARN;
     }
+    if (level != DiagStatus::OK) {
+      if (error_str != "") error_str += ", ";
+      error_str += broadcast_code + ": " + pps_dict_.at(level);
+    }
 
     stat.add(broadcast_code, pps_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, pps_dict_.at(whole_level));
+  stat.summary(whole_level, error_str);
 }
 
 void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -963,6 +997,7 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -985,12 +1020,16 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat)
     if (status == ServiceLifeStatus::Warning) {
       level = DiagStatus::WARN;
     }
+    if (level != DiagStatus::OK) {
+      if (error_str != "") error_str += ", ";
+      error_str += broadcast_code + ": " + life_dict_.at(level);
+    }
 
     stat.add(broadcast_code, life_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, life_dict_.at(whole_level));
+  stat.summary(whole_level, error_str);
 }
 
 void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -1001,6 +1040,7 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -1023,12 +1063,16 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat)
     if (status == FanStatus::Warning) {
       level = DiagStatus::WARN;
     }
+    if (level != DiagStatus::OK) {
+      if (error_str != "") error_str += ", ";
+      error_str += broadcast_code + ": " + fan_dict_.at(level);
+    }
 
     stat.add(broadcast_code, fan_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, fan_dict_.at(whole_level));
+  stat.summary(whole_level, error_str);
 }
 
 void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -1039,6 +1083,7 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -1062,11 +1107,16 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
       level = DiagStatus::WARN;
     }
 
+    if (level != DiagStatus::OK) {
+      if (error_str != "") error_str += ", ";
+      error_str += broadcast_code + ": " + ptp_dict_.at(level);
+    }
+
     stat.add(broadcast_code, ptp_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, ptp_dict_.at(whole_level));
+  stat.summary(whole_level, error_str);
 }
 
 void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -1077,6 +1127,7 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 
   int whole_level = DiagStatus::OK;
+  std::string error_str = "";
 
   for (const auto & lidar : lds_->connected_lidars_) {
     int level = DiagStatus::OK;
@@ -1099,12 +1150,16 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat)
     if (status == TimeSyncStatus::Abnormal) {
       level = DiagStatus::WARN;
     }
+    if (level != DiagStatus::OK) {
+      if (error_str != "") error_str += ", ";
+      error_str += broadcast_code + ": " + time_sync_dict_.at(level);
+    }
 
     stat.add(broadcast_code, time_sync_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
-  stat.summary(whole_level, time_sync_dict_.at(whole_level));
+  stat.summary(whole_level, error_str);
 }
 
 void Lddc::checkConnection(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -1121,7 +1176,8 @@ void Lddc::checkConnection(diagnostic_updater::DiagnosticStatusWrapper & stat)
     const auto & device_info = lidar.second;
 
     if (device_info == nullptr) {
-      error_str = "LiDAR disconnected";
+      if (error_str != "") error_str += ", ";
+      error_str += broadcast_code + ": " + "disconnected";
       stat.add(broadcast_code, "disconnected");
       continue;
     }

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -1141,43 +1141,4 @@ void Lddc::checkConnection(diagnostic_updater::DiagnosticStatusWrapper & stat)
     stat.summary(DiagStatus::OK, "OK");
   }
 }
-
-void Lddc::checkConnection(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  if (lidar_count_ == 0) {
-    stat.summary(DiagStatus::WARN, "No LiDARs Connected");
-    return;
-  }
-
-  int whole_level = DiagStatus::OK;
-  std::string error_str = "";
-
-  for (const auto & lidar : lds_->connected_lidars_) {
-    int level = DiagStatus::OK;
-
-    const auto & broadcast_code = lidar.first;
-    const auto & device_info = lidar.second;
-
-    if (device_info == nullptr) {
-      error_str = "LiDAR disconnected";
-      stat.add(broadcast_code, "disconnected");
-      continue;
-    }
-
-    if (device_info->state == kLidarStateInit) {
-      stat.addf(broadcast_code, "%d%%", device_info->status.progress);
-      continue;
-    }
-
-    stat.add(broadcast_code, connection_dict_.at(level));
-    whole_level = std::max(whole_level, level);
-  }
-
-  if (!error_str.empty()) {
-    stat.summary(DiagStatus::ERROR, error_str);
-  }
-  else {
-    stat.summary(whole_level, connection_dict_.at(whole_level));
-  }
-}
 }  // namespace livox_ros

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -798,7 +798,7 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper &stat,
                             const std::string & broadcast_code)
 {
   int level = DiagStatus::OK;
-  std::string error_str = temperature_dict_.at(level);
+  std::string error_str = "OK";
 
   std::pair<std::string, DeviceInfo*> lidar;
   getLidarByBroadcastcode(lidar, broadcast_code);
@@ -836,7 +836,7 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper &stat,
                         const std::string &broadcast_code)
 {
   int level = DiagStatus::OK;
-  std::string error_str = voltage_dict_.at(level);
+  std::string error_str = "OK";
 
   std::pair<std::string, DeviceInfo*> lidar;
   getLidarByBroadcastcode(lidar, broadcast_code);
@@ -873,7 +873,7 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper &stat,
                       const std::string &broadcast_code)
 {
   int level = DiagStatus::OK;
-  std::string error_str = motor_dict_.at(level);
+  std::string error_str = "OK";
 
   std::pair<std::string, DeviceInfo*> lidar;
   getLidarByBroadcastcode(lidar, broadcast_code);
@@ -911,7 +911,7 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper &stat,
                       const std::string &broadcast_code)
 {
   int level = DiagStatus::OK;
-  std::string error_str = dirty_dict_.at(level);
+  std::string error_str = "OK";
 
   std::pair<std::string, DeviceInfo*> lidar;
   getLidarByBroadcastcode(lidar, broadcast_code);
@@ -945,7 +945,7 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper &stat,
                          const std::string &broadcast_code)
 {
   int level = DiagStatus::OK;
-  std::string error_str = firmware_dict_.at(level);
+  std::string error_str = "OK";
 
   std::pair<std::string, DeviceInfo*> lidar;
   getLidarByBroadcastcode(lidar, broadcast_code);
@@ -979,7 +979,7 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper &stat,
                           const std::string &broadcast_code)
 {
   int level = DiagStatus::OK;
-  std::string error_str = pps_dict_.at(level);
+  std::string error_str = "OK";
 
   std::pair<std::string, DeviceInfo*> lidar;
   getLidarByBroadcastcode(lidar, broadcast_code);
@@ -1013,7 +1013,7 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper &stat,
                             const std::string &broadcast_code)
 {
   int level = DiagStatus::OK;
-  std::string error_str = life_dict_.at(level);
+  std::string error_str = "OK";
 
   std::pair<std::string, DeviceInfo*> lidar;
   getLidarByBroadcastcode(lidar, broadcast_code);
@@ -1047,7 +1047,7 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper &stat,
                     const std::string &broadcast_code)
 {
   int level = DiagStatus::OK;
-  std::string error_str = fan_dict_.at(level);
+  std::string error_str = "OK";
 
   std::pair<std::string, DeviceInfo*> lidar;
   getLidarByBroadcastcode(lidar, broadcast_code);
@@ -1080,7 +1080,7 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper &stat,
 void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper &stat, const std::string &broadcast_code)
 {
   int level = DiagStatus::OK;
-  std::string error_str = ptp_dict_.at(level);
+  std::string error_str = "OK";
 
   std::pair<std::string, DeviceInfo*> lidar;
   getLidarByBroadcastcode(lidar, broadcast_code);
@@ -1113,7 +1113,7 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper &stat,
                          const std::string &broadcast_code)
 {
   int level = DiagStatus::OK;
-  std::string error_str = time_sync_dict_.at(level);
+  std::string error_str = "OK";
 
   std::pair<std::string, DeviceInfo*> lidar;
   getLidarByBroadcastcode(lidar, broadcast_code);

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -702,6 +702,72 @@ void Lddc::initializeDiagnostics()
   cur_node_->get_node_timers_interface()->add_timer(timer_, nullptr);
 }
 
+void Lddc::registerDiagnosticsUpdater(const std::string &broadcast_code)
+{
+  updater_.add(
+      fmt::format("livox_temperature_{}", broadcast_code),
+      std::bind(
+          &Lddc::checkTemperature, this, std::placeholders::_1,
+          broadcast_code));
+
+  updater_.add(
+      fmt::format("livox_internal_voltage_{}", broadcast_code),
+      std::bind(
+          &Lddc::checkVoltage, this, std::placeholders::_1,
+          broadcast_code));
+
+  updater_.add(
+      fmt::format("livox_motor_status_{}", broadcast_code),
+      std::bind(
+          &Lddc::checkMotor, this, std::placeholders::_1,
+          broadcast_code));
+
+  updater_.add(
+      fmt::format("livox_optical_window_{}", broadcast_code),
+      std::bind(
+          &Lddc::checkDirty, this, std::placeholders::_1,
+          broadcast_code));
+
+  updater_.add(
+      fmt::format("livox_firmware_status_{}", broadcast_code),
+      std::bind(
+          &Lddc::checkFirmware, this, std::placeholders::_1,
+          broadcast_code));
+
+  if (check_pps_signal_)
+  {
+    updater_.add(
+        fmt::format("livox_pps_signal_{}", broadcast_code),
+        std::bind(
+            &Lddc::checkPPSSignal, this, std::placeholders::_1,
+            broadcast_code));
+  }
+
+  updater_.add(
+      fmt::format("livox_service_life_{}", broadcast_code),
+      std::bind(
+          &Lddc::checkServiceLife, this, std::placeholders::_1,
+          broadcast_code));
+
+  updater_.add(
+      fmt::format("livox_fan_status_{}", broadcast_code),
+      std::bind(
+          &Lddc::checkFan, this, std::placeholders::_1,
+          broadcast_code));
+
+  updater_.add(
+      fmt::format("livox_time_sync_{}", broadcast_code),
+      std::bind(
+          &Lddc::checkTimeSync, this, std::placeholders::_1,
+          broadcast_code));
+
+  updater_.add(
+      fmt::format("livox_connection_{}", broadcast_code),
+      std::bind(
+          &Lddc::checkConnection, this, std::placeholders::_1,
+          broadcast_code));
+}
+
 void Lddc::onDiagnosticsTimer()
 {
   lidar_count_ = 0;
@@ -715,69 +781,7 @@ void Lddc::onDiagnosticsTimer()
     for (const auto &lidar : lds_->connected_lidars_)
     {
       const std::string broadcast_code = lidar.first;
-
-      updater_.add(
-          fmt::format("livox_temperature_{}", broadcast_code),
-          std::bind(
-              &Lddc::checkTemperature, this, std::placeholders::_1,
-              broadcast_code));
-
-      updater_.add(
-          fmt::format("livox_internal_voltage_{}", broadcast_code),
-          std::bind(
-              &Lddc::checkVoltage, this, std::placeholders::_1,
-              broadcast_code));
-
-      updater_.add(
-          fmt::format("livox_motor_status_{}", broadcast_code),
-          std::bind(
-              &Lddc::checkMotor, this, std::placeholders::_1,
-              broadcast_code));
-
-      updater_.add(
-          fmt::format("livox_optical_window_{}", broadcast_code),
-          std::bind(
-              &Lddc::checkDirty, this, std::placeholders::_1,
-              broadcast_code));
-
-      updater_.add(
-          fmt::format("livox_firmware_status_{}", broadcast_code),
-          std::bind(
-              &Lddc::checkFirmware, this, std::placeholders::_1,
-              broadcast_code));
-
-      if (check_pps_signal_)
-      {
-        updater_.add(
-            fmt::format("livox_pps_signal_{}", broadcast_code),
-            std::bind(
-                &Lddc::checkPPSSignal, this, std::placeholders::_1,
-                broadcast_code));
-      }
-
-      updater_.add(
-          fmt::format("livox_service_life_{}", broadcast_code),
-          std::bind(
-              &Lddc::checkServiceLife, this, std::placeholders::_1,
-              broadcast_code));
-
-      updater_.add(
-          fmt::format("livox_fan_status_{}", broadcast_code),
-          std::bind(
-              &Lddc::checkFan, this, std::placeholders::_1,
-              broadcast_code));
-
-      updater_.add(
-          fmt::format("livox_time_sync_{}", broadcast_code),
-          std::bind(
-              &Lddc::checkTimeSync, this, std::placeholders::_1,
-              broadcast_code));
-
-      updater_.add(
-          fmt::format("livox_connection_{}", broadcast_code),
-          std::bind(
-              &Lddc::checkConnection, this, std::placeholders::_1,
-              broadcast_code));
+      Lddc::registerDiagnosticsUpdater(broadcast_code);
     }
   }
 

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -704,67 +704,49 @@ void Lddc::initializeDiagnostics()
 
 void Lddc::registerDiagnosticsUpdater(const std::string &broadcast_code)
 {
-  updater_.add(
-      fmt::format("livox_temperature-{}", broadcast_code),
-      std::bind(
-          &Lddc::checkTemperature, this, std::placeholders::_1,
-          broadcast_code));
+  if (registered_code_set_.count(broadcast_code) == 0) {
+    updater_.add(fmt::format("livox_temperature-{}", broadcast_code),
+                 std::bind(&Lddc::checkTemperature, this, std::placeholders::_1,
+                           broadcast_code));
 
-  updater_.add(
-      fmt::format("livox_internal_voltage-{}", broadcast_code),
-      std::bind(
-          &Lddc::checkVoltage, this, std::placeholders::_1,
-          broadcast_code));
+    updater_.add(fmt::format("livox_internal_voltage-{}", broadcast_code),
+                 std::bind(&Lddc::checkVoltage, this, std::placeholders::_1,
+                           broadcast_code));
 
-  updater_.add(
-      fmt::format("livox_motor_status-{}", broadcast_code),
-      std::bind(
-          &Lddc::checkMotor, this, std::placeholders::_1,
-          broadcast_code));
+    updater_.add(fmt::format("livox_motor_status-{}", broadcast_code),
+                 std::bind(&Lddc::checkMotor, this, std::placeholders::_1,
+                           broadcast_code));
 
-  updater_.add(
-      fmt::format("livox_optical_window-{}", broadcast_code),
-      std::bind(
-          &Lddc::checkDirty, this, std::placeholders::_1,
-          broadcast_code));
+    updater_.add(fmt::format("livox_optical_window-{}", broadcast_code),
+                 std::bind(&Lddc::checkDirty, this, std::placeholders::_1,
+                           broadcast_code));
 
-  updater_.add(
-      fmt::format("livox_firmware_status-{}", broadcast_code),
-      std::bind(
-          &Lddc::checkFirmware, this, std::placeholders::_1,
-          broadcast_code));
+    updater_.add(fmt::format("livox_firmware_status-{}", broadcast_code),
+                 std::bind(&Lddc::checkFirmware, this, std::placeholders::_1,
+                           broadcast_code));
 
-  if (check_pps_signal_) {
-    updater_.add(
-        fmt::format("livox_pps_signal-{}", broadcast_code),
-        std::bind(
-            &Lddc::checkPPSSignal, this, std::placeholders::_1,
-            broadcast_code));
+    if (check_pps_signal_) {
+      updater_.add(fmt::format("livox_pps_signal-{}", broadcast_code),
+                   std::bind(&Lddc::checkPPSSignal, this, std::placeholders::_1,
+                             broadcast_code));
+    }
+
+    updater_.add(fmt::format("livox_service_life-{}", broadcast_code),
+                 std::bind(&Lddc::checkServiceLife, this, std::placeholders::_1,
+                           broadcast_code));
+
+    updater_.add(fmt::format("livox_fan_status-{}", broadcast_code),
+                 std::bind(&Lddc::checkFan, this, std::placeholders::_1,
+                           broadcast_code));
+
+    updater_.add(fmt::format("livox_time_sync-{}", broadcast_code),
+                 std::bind(&Lddc::checkTimeSync, this, std::placeholders::_1,
+                           broadcast_code));
+
+    updater_.add(fmt::format("livox_connection-{}", broadcast_code),
+                 std::bind(&Lddc::checkConnection, this, std::placeholders::_1,
+                           broadcast_code));
   }
-
-  updater_.add(
-      fmt::format("livox_service_life-{}", broadcast_code),
-      std::bind(
-          &Lddc::checkServiceLife, this, std::placeholders::_1,
-          broadcast_code));
-
-  updater_.add(
-      fmt::format("livox_fan_status-{}", broadcast_code),
-      std::bind(
-          &Lddc::checkFan, this, std::placeholders::_1,
-          broadcast_code));
-
-  updater_.add(
-      fmt::format("livox_time_sync-{}", broadcast_code),
-      std::bind(
-          &Lddc::checkTimeSync, this, std::placeholders::_1,
-          broadcast_code));
-
-  updater_.add(
-      fmt::format("livox_connection-{}", broadcast_code),
-      std::bind(
-          &Lddc::checkConnection, this, std::placeholders::_1,
-          broadcast_code));
 }
 
 void Lddc::onDiagnosticsTimer()

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -702,52 +702,48 @@ void Lddc::initializeDiagnostics()
   cur_node_->get_node_timers_interface()->add_timer(timer_, nullptr);
 }
 
-void Lddc::registerDiagnosticsUpdater(const std::string &broadcast_code)
-{
-  registered_code_set_.insert(broadcast_code);
-  if (registered_code_set_.count(broadcast_code) == 0) {
-    updater_.add(fmt::format("livox_temperature-{}", broadcast_code),
-                 std::bind(&Lddc::checkTemperature, this, std::placeholders::_1,
-                           broadcast_code));
+void Lddc::registerDiagnosticsUpdater(const std::string &broadcast_code) {
+  updater_.add(fmt::format("livox_temperature-{}", broadcast_code),
+               std::bind(&Lddc::checkTemperature, this, std::placeholders::_1,
+                         broadcast_code));
 
-    updater_.add(fmt::format("livox_internal_voltage-{}", broadcast_code),
-                 std::bind(&Lddc::checkVoltage, this, std::placeholders::_1,
-                           broadcast_code));
+  updater_.add(fmt::format("livox_internal_voltage-{}", broadcast_code),
+               std::bind(&Lddc::checkVoltage, this, std::placeholders::_1,
+                         broadcast_code));
 
-    updater_.add(fmt::format("livox_motor_status-{}", broadcast_code),
-                 std::bind(&Lddc::checkMotor, this, std::placeholders::_1,
-                           broadcast_code));
+  updater_.add(fmt::format("livox_motor_status-{}", broadcast_code),
+               std::bind(&Lddc::checkMotor, this, std::placeholders::_1,
+                         broadcast_code));
 
-    updater_.add(fmt::format("livox_optical_window-{}", broadcast_code),
-                 std::bind(&Lddc::checkDirty, this, std::placeholders::_1,
-                           broadcast_code));
+  updater_.add(fmt::format("livox_optical_window-{}", broadcast_code),
+               std::bind(&Lddc::checkDirty, this, std::placeholders::_1,
+                         broadcast_code));
 
-    updater_.add(fmt::format("livox_firmware_status-{}", broadcast_code),
-                 std::bind(&Lddc::checkFirmware, this, std::placeholders::_1,
-                           broadcast_code));
+  updater_.add(fmt::format("livox_firmware_status-{}", broadcast_code),
+               std::bind(&Lddc::checkFirmware, this, std::placeholders::_1,
+                         broadcast_code));
 
-    if (check_pps_signal_) {
-      updater_.add(fmt::format("livox_pps_signal-{}", broadcast_code),
-                   std::bind(&Lddc::checkPPSSignal, this, std::placeholders::_1,
-                             broadcast_code));
-    }
-
-    updater_.add(fmt::format("livox_service_life-{}", broadcast_code),
-                 std::bind(&Lddc::checkServiceLife, this, std::placeholders::_1,
-                           broadcast_code));
-
-    updater_.add(fmt::format("livox_fan_status-{}", broadcast_code),
-                 std::bind(&Lddc::checkFan, this, std::placeholders::_1,
-                           broadcast_code));
-
-    updater_.add(fmt::format("livox_time_sync-{}", broadcast_code),
-                 std::bind(&Lddc::checkTimeSync, this, std::placeholders::_1,
-                           broadcast_code));
-
-    updater_.add(fmt::format("livox_connection-{}", broadcast_code),
-                 std::bind(&Lddc::checkConnection, this, std::placeholders::_1,
+  if (check_pps_signal_) {
+    updater_.add(fmt::format("livox_pps_signal-{}", broadcast_code),
+                 std::bind(&Lddc::checkPPSSignal, this, std::placeholders::_1,
                            broadcast_code));
   }
+
+  updater_.add(fmt::format("livox_service_life-{}", broadcast_code),
+               std::bind(&Lddc::checkServiceLife, this, std::placeholders::_1,
+                         broadcast_code));
+
+  updater_.add(
+      fmt::format("livox_fan_status-{}", broadcast_code),
+      std::bind(&Lddc::checkFan, this, std::placeholders::_1, broadcast_code));
+
+  updater_.add(fmt::format("livox_time_sync-{}", broadcast_code),
+               std::bind(&Lddc::checkTimeSync, this, std::placeholders::_1,
+                         broadcast_code));
+
+  updater_.add(fmt::format("livox_connection-{}", broadcast_code),
+               std::bind(&Lddc::checkConnection, this, std::placeholders::_1,
+                         broadcast_code));
 }
 
 void Lddc::onDiagnosticsTimer()
@@ -761,7 +757,10 @@ void Lddc::onDiagnosticsTimer()
     connected_lidar_count_ = lds_->connected_lidars_.size();
     for (const auto &lidar : lds_->connected_lidars_) {
       const std::string broadcast_code = lidar.first;
-      Lddc::registerDiagnosticsUpdater(broadcast_code);
+      registered_code_set_.insert(broadcast_code);
+      if (registered_code_set_.count(broadcast_code) == 0) {
+        Lddc::registerDiagnosticsUpdater(broadcast_code);
+      }
     }
   }
 

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -753,14 +753,11 @@ void Lddc::onDiagnosticsTimer()
     if (lds_->lidars_[i].handle != kMaxSourceLidar) ++lidar_count_;
   }
 
-  if (connected_lidar_count_ != lds_->connected_lidars_.size()) {
-    connected_lidar_count_ = lds_->connected_lidars_.size();
-    for (const auto &lidar : lds_->connected_lidars_) {
-      const std::string broadcast_code = lidar.first;
+  for (const auto &lidar : lds_->connected_lidars_) {
+    const std::string broadcast_code = lidar.first;
+    if (registered_code_set_.count(broadcast_code) == 0) {
+      Lddc::registerDiagnosticsUpdater(broadcast_code);
       registered_code_set_.insert(broadcast_code);
-      if (registered_code_set_.count(broadcast_code) == 0) {
-        Lddc::registerDiagnosticsUpdater(broadcast_code);
-      }
     }
   }
 

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -764,6 +764,7 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
+  if (whole_level == DiagStatus::OK) error_str = temperature_dict_.at(whole_level);
   stat.summary(whole_level, error_str);
 }
 
@@ -810,6 +811,7 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
+  if (whole_level == DiagStatus::OK) error_str = voltage_dict_.at(whole_level);
   stat.summary(whole_level, error_str);
 }
 
@@ -856,6 +858,7 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
+  if (whole_level == DiagStatus::OK) error_str = motor_dict_.at(whole_level);
   stat.summary(whole_level, error_str);
 }
 
@@ -900,6 +903,7 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
+  if (whole_level == DiagStatus::OK) error_str = dirty_dict_.at(whole_level);
   stat.summary(whole_level, error_str);
 }
 
@@ -943,6 +947,7 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
+  if (whole_level == DiagStatus::OK) error_str = firmware_dict_.at(whole_level);
   stat.summary(whole_level, error_str);
 }
 
@@ -986,6 +991,7 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
+  if (whole_level == DiagStatus::OK) error_str = pps_dict_.at(whole_level);
   stat.summary(whole_level, error_str);
 }
 
@@ -1029,6 +1035,7 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
+  if (whole_level == DiagStatus::OK) error_str = life_dict_.at(whole_level);
   stat.summary(whole_level, error_str);
 }
 
@@ -1072,6 +1079,7 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
+  if (whole_level == DiagStatus::OK) error_str = fan_dict_.at(whole_level);
   stat.summary(whole_level, error_str);
 }
 
@@ -1116,6 +1124,7 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
+  if (whole_level == DiagStatus::OK) error_str = ptp_dict_.at(whole_level);
   stat.summary(whole_level, error_str);
 }
 
@@ -1159,6 +1168,7 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat)
     whole_level = std::max(whole_level, level);
   }
 
+  if (whole_level == DiagStatus::OK) error_str = time_sync_dict_.at(whole_level);
   stat.summary(whole_level, error_str);
 }
 

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -781,7 +781,7 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  if (*device_info == nullptr) {
+  if (!device_info) {
     error_str = "disconnected";
   } else if ((*device_info)->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
@@ -808,7 +808,7 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  if (*device_info == nullptr) {
+  if (!device_info) {
     error_str = "disconnected";
   } else if ((*device_info)->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
@@ -835,7 +835,7 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  if (*device_info == nullptr) {
+  if (!device_info) {
     error_str = "disconnected";
   } else if ((*device_info)->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
@@ -862,7 +862,7 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  if (*device_info == nullptr) {
+  if (!device_info) {
     error_str = "disconnected";
   } else if ((*device_info)->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
@@ -887,7 +887,7 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  if (*device_info == nullptr) {
+  if (!device_info) {
     error_str = "disconnected";
   } else if ((*device_info)->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
@@ -912,7 +912,7 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  if (*device_info == nullptr) {
+  if (!device_info) {
     error_str = "disconnected";
   } else if ((*device_info)->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
@@ -937,7 +937,7 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  if (*device_info == nullptr) {
+  if (!device_info) {
     error_str = "disconnected";
   } else if ((*device_info)->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
@@ -962,7 +962,7 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  if (*device_info == nullptr) {
+  if (!device_info) {
     error_str = "disconnected";
   } else if ((*device_info)->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
@@ -986,7 +986,7 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper &stat, con
 
   const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  if (*device_info == nullptr) {
+  if (!device_info) {
     error_str = "disconnected";
   } else if ((*device_info)->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
@@ -1011,7 +1011,7 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  if (*device_info == nullptr) {
+  if (!device_info) {
     error_str = "disconnected";
   } else if ((*device_info)->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
@@ -1036,7 +1036,7 @@ void Lddc::checkConnection(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  if (*device_info == nullptr) {
+  if (!device_info) {
     level = DiagStatus::ERROR;
     error_str = "disconnected";
   } else if ((*device_info)->state == kLidarStateInit) {

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -768,7 +768,7 @@ void Lddc::onDiagnosticsTimer()
               broadcast_code));
 
       updater_.add(
-          fmt::format("livox_time_sync{}", broadcast_code),
+          fmt::format("livox_time_sync_{}", broadcast_code),
           std::bind(
               &Lddc::checkTimeSync, this, std::placeholders::_1,
               broadcast_code));

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -714,7 +714,7 @@ void Lddc::onDiagnosticsTimer()
     connected_lidar_count_ = lds_->connected_lidars_.size();
     for (const auto &lidar : lds_->connected_lidars_)
     {
-      std::string broadcast_code = lidar.first;
+      const std::string broadcast_code = lidar.first;
 
       updater_.add(
           fmt::format("livox_temperature_{}", broadcast_code),
@@ -787,9 +787,9 @@ void Lddc::onDiagnosticsTimer()
 void Lddc::getLidarByBroadcastcode(std::pair<std::string, DeviceInfo *> &lidar,
                                    const std::string &broadcast_code)
 {
-  for (const auto & tmp_lidar : lds_->connected_lidars_) {
-    const std::string tmp_broadcast_code = tmp_lidar.first;
-    if (tmp_broadcast_code == broadcast_code) lidar = tmp_lidar;
+  for (const auto & connected_lidar : lds_->connected_lidars_) {
+    const std::string connected_broadcast_code = connected_lidar.first;
+    if (connected_broadcast_code == broadcast_code) lidar = connected_lidar;
   }
 }
 

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -796,7 +796,7 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = temperature_dict_.at(level);
   }
 
-  stat.add(broadcast_code, error_str);
+  stat.add("broadcast_code", broadcast_code);
   stat.summary(level, error_str);
 }
 
@@ -823,7 +823,7 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = voltage_dict_.at(level);
   }
 
-    stat.add(broadcast_code, error_str);
+    stat.add("broadcast_code", broadcast_code);
     stat.summary(level, error_str);
 }
 
@@ -850,7 +850,7 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = motor_dict_.at(level);
   }
 
-  stat.add(broadcast_code, error_str);
+  stat.add("broadcast_code", broadcast_code);
   stat.summary(level, error_str);
 }
 
@@ -875,7 +875,7 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = dirty_dict_.at(level);
   }
 
-  stat.add(broadcast_code, error_str);
+  stat.add("broadcast_code", broadcast_code);
   stat.summary(level, error_str);
 }
 
@@ -900,7 +900,7 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = firmware_dict_.at(level);
   }
 
-  stat.add(broadcast_code, error_str);
+  stat.add("broadcast_code", broadcast_code);
   stat.summary(level, error_str);
 }
 
@@ -925,7 +925,7 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = pps_dict_.at(level);
   }
 
-  stat.add(broadcast_code, error_str);
+  stat.add("broadcast_code", broadcast_code);
   stat.summary(level, error_str);
 }
 
@@ -950,7 +950,7 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = life_dict_.at(level);
   }
 
-  stat.add(broadcast_code, error_str);
+  stat.add("broadcast_code", broadcast_code);
   stat.summary(level, error_str);
 }
 
@@ -975,7 +975,7 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = fan_dict_.at(level);
   }
 
-  stat.add(broadcast_code, error_str);
+  stat.add("broadcast_code", broadcast_code);
   stat.summary(level, error_str);
 }
 
@@ -999,7 +999,7 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper &stat, con
     error_str = ptp_dict_.at(level);
   }
 
-  stat.add(broadcast_code, error_str);
+  stat.add("broadcast_code", broadcast_code);
   stat.summary(level, error_str);
 }
 
@@ -1024,7 +1024,7 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = time_sync_dict_.at(level);
   }
 
-  stat.add(broadcast_code, error_str);
+  stat.add("broadcast_code", broadcast_code);
   stat.summary(level, error_str);
 }
 
@@ -1044,7 +1044,7 @@ void Lddc::checkConnection(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
   }
 
-  stat.add(broadcast_code, error_str);
+  stat.add("broadcast_code", broadcast_code);
   stat.summary(level, error_str);
 }
 }  // namespace livox_ros

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -734,8 +734,7 @@ void Lddc::registerDiagnosticsUpdater(const std::string &broadcast_code)
           &Lddc::checkFirmware, this, std::placeholders::_1,
           broadcast_code));
 
-  if (check_pps_signal_)
-  {
+  if (check_pps_signal_) {
     updater_.add(
         fmt::format("livox_pps_signal-{}", broadcast_code),
         std::bind(
@@ -775,11 +774,9 @@ void Lddc::onDiagnosticsTimer()
     if (lds_->lidars_[i].handle != kMaxSourceLidar) ++lidar_count_;
   }
 
-  if (connected_lidar_count_ != lds_->connected_lidars_.size())
-  {
+  if (connected_lidar_count_ != lds_->connected_lidars_.size()) {
     connected_lidar_count_ = lds_->connected_lidars_.size();
-    for (const auto &lidar : lds_->connected_lidars_)
-    {
+    for (const auto &lidar : lds_->connected_lidars_) {
       const std::string broadcast_code = lidar.first;
       Lddc::registerDiagnosticsUpdater(broadcast_code);
     }
@@ -808,24 +805,16 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   const auto & device_info = lidar.second;
 
-  if (device_info == nullptr)
-  {
+  if (device_info == nullptr) {
     error_str = "disconnected";
-  }
-  else if (device_info->state == kLidarStateInit)
-  {
+  } else if (device_info->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
-  }
-  else
-  {
+  } else {
     TemperatureStatus status = static_cast<TemperatureStatus>(
         device_info->status.status_code.lidar_error_code.temp_status);
-    if (status == TemperatureStatus::HighOrLow)
-    {
+    if (status == TemperatureStatus::HighOrLow) {
       level = DiagStatus::WARN;
-    }
-    else if (status == TemperatureStatus::ExtremelyHighOrLow)
-    {
+    } else if (status == TemperatureStatus::ExtremelyHighOrLow) {
       level = DiagStatus::ERROR;
     }
     error_str = temperature_dict_.at(level);
@@ -848,25 +837,18 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   if (device_info == nullptr) {
     error_str = "disconnected";
+  } else if (device_info->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", device_info->status.progress);
+  } else {
+    VoltageStatus status = static_cast<VoltageStatus>(
+        device_info->status.status_code.lidar_error_code.volt_status);
+    if (status == VoltageStatus::High) {
+      level = DiagStatus::WARN;
+    } else if (status == VoltageStatus::ExtremelyHigh) {
+      level = DiagStatus::ERROR;
     }
-    else if (device_info->state == kLidarStateInit)
-    {
-      error_str = fmt::format("progress: %d%%", device_info->status.progress);
-    }
-    else
-    {
-      VoltageStatus status = static_cast<VoltageStatus>(
-          device_info->status.status_code.lidar_error_code.volt_status);
-      if (status == VoltageStatus::High)
-      {
-        level = DiagStatus::WARN;
-      }
-      else if (status == VoltageStatus::ExtremelyHigh)
-      {
-        level = DiagStatus::ERROR;
-      }
-      error_str = voltage_dict_.at(level);
-    }
+    error_str = voltage_dict_.at(level);
+  }
 
     stat.add(broadcast_code, error_str);
     stat.summary(level, error_str);
@@ -881,26 +863,18 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper &stat,
   std::pair<std::string, DeviceInfo*> lidar;
   getLidarByBroadcastcode(lidar, broadcast_code);
 
-  const auto & device_info = lidar.second;
+  const auto &device_info = lidar.second;
 
-  if (device_info == nullptr)
-  {
+  if (device_info == nullptr) {
     error_str = "disconnected";
-  }
-  else if (device_info->state == kLidarStateInit)
-  {
+  } else if (device_info->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
-  }
-  else
-  {
+  } else {
     MotorStatus status = static_cast<MotorStatus>(
         device_info->status.status_code.lidar_error_code.motor_status);
-    if (status == MotorStatus::Warning)
-    {
+    if (status == MotorStatus::Warning) {
       level = DiagStatus::WARN;
-    }
-    else if (status == MotorStatus::Error)
-    {
+    } else if (status == MotorStatus::Error) {
       level = DiagStatus::ERROR;
     }
     error_str = motor_dict_.at(level);
@@ -921,20 +895,14 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   const auto & device_info = lidar.second;
 
-  if (device_info == nullptr)
-  {
+  if (device_info == nullptr) {
     error_str = "disconnected";
-  }
-  else if (device_info->state == kLidarStateInit)
-  {
+  } else if (device_info->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
-  }
-  else
-  {
+  } else {
     DirtyStatus status = static_cast<DirtyStatus>(
         device_info->status.status_code.lidar_error_code.dirty_warn);
-    if (status == DirtyStatus::DirtyOrBlocked)
-    {
+    if (status == DirtyStatus::DirtyOrBlocked) {
       level = DiagStatus::WARN;
     }
     error_str = dirty_dict_.at(level);
@@ -953,22 +921,16 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper &stat,
   std::pair<std::string, DeviceInfo*> lidar;
   getLidarByBroadcastcode(lidar, broadcast_code);
 
-  const auto & device_info = lidar.second;
+  const auto &device_info = lidar.second;
 
-  if (device_info == nullptr)
-  {
+  if (device_info == nullptr) {
     error_str = "disconnected";
-  }
-  else if (device_info->state == kLidarStateInit)
-  {
+  } else if (device_info->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
-  }
-  else
-  {
+  } else {
     FirmwareStatus status = static_cast<FirmwareStatus>(
         device_info->status.status_code.lidar_error_code.firmware_err);
-    if (status == FirmwareStatus::Abnormal)
-    {
+    if (status == FirmwareStatus::Abnormal) {
       level = DiagStatus::ERROR;
     }
     error_str = firmware_dict_.at(level);
@@ -987,22 +949,16 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper &stat,
   std::pair<std::string, DeviceInfo*> lidar;
   getLidarByBroadcastcode(lidar, broadcast_code);
 
-  const auto & device_info = lidar.second;
+  const auto &device_info = lidar.second;
 
-  if (device_info == nullptr)
-  {
+  if (device_info == nullptr) {
     error_str = "disconnected";
-  }
-  else if (device_info->state == kLidarStateInit)
-  {
+  } else if (device_info->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
-  }
-  else
-  {
+  } else {
     PPSSignalStatus status = static_cast<PPSSignalStatus>(
         device_info->status.status_code.lidar_error_code.pps_status);
-    if (status == PPSSignalStatus::NoSignal)
-    {
+    if (status == PPSSignalStatus::NoSignal) {
       level = DiagStatus::WARN;
     }
     error_str = pps_dict_.at(level);
@@ -1023,20 +979,14 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   const auto & device_info = lidar.second;
 
-  if (device_info == nullptr)
-  {
+  if (device_info == nullptr) {
     error_str = "disconnected";
-  }
-  else if (device_info->state == kLidarStateInit)
-  {
+  } else if (device_info->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
-  }
-  else
-  {
+  } else {
     ServiceLifeStatus status = static_cast<ServiceLifeStatus>(
         device_info->status.status_code.lidar_error_code.device_status);
-    if (status == ServiceLifeStatus::Warning)
-    {
+    if (status == ServiceLifeStatus::Warning) {
       level = DiagStatus::WARN;
     }
     error_str = life_dict_.at(level);
@@ -1057,20 +1007,14 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   const auto & device_info = lidar.second;
 
-  if (device_info == nullptr)
-  {
+  if (device_info == nullptr) {
     error_str = "disconnected";
-  }
-  else if (device_info->state == kLidarStateInit)
-  {
+  } else if (device_info->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
-  }
-  else
-  {
+  } else {
     FanStatus status = static_cast<FanStatus>(
         device_info->status.status_code.lidar_error_code.fan_status);
-    if (status == FanStatus::Warning)
-    {
+    if (status == FanStatus::Warning) {
       level = DiagStatus::WARN;
     }
     error_str = fan_dict_.at(level);
@@ -1090,18 +1034,13 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper &stat, con
 
   const auto & device_info = lidar.second;
 
-  if (device_info == nullptr)
-  {
+  if (device_info == nullptr) {
     error_str = "disconnected";
-  }
-  else if (device_info->state == kLidarStateInit)
-  {
+  } else if (device_info->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
-  }
-  else
-  {
+  } else {
     PTPSignalStatus status = static_cast<PTPSignalStatus>(
-      device_info->status.status_code.lidar_error_code.ptp_status);
+        device_info->status.status_code.lidar_error_code.ptp_status);
     if (status == PTPSignalStatus::NoSignal) {
       level = DiagStatus::WARN;
     }
@@ -1123,18 +1062,13 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   const auto & device_info = lidar.second;
 
-  if (device_info == nullptr)
-  {
+  if (device_info == nullptr) {
     error_str = "disconnected";
-  }
-  else if (device_info->state == kLidarStateInit)
-  {
+  } else if (device_info->state == kLidarStateInit) {
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
-  }
-  else
-  {
+  } else {
     TimeSyncStatus status = static_cast<TimeSyncStatus>(
-      device_info->status.status_code.lidar_error_code.time_sync_status);
+        device_info->status.status_code.lidar_error_code.time_sync_status);
     if (status == TimeSyncStatus::Abnormal) {
       level = DiagStatus::WARN;
     }
@@ -1156,12 +1090,10 @@ void Lddc::checkConnection(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   const auto & device_info = lidar.second;
 
-  if (device_info == nullptr)
-  {
+  if (device_info == nullptr) {
     level = DiagStatus::ERROR;
     error_str = "disconnected";
-  }
-  else if (device_info->state == kLidarStateInit) {
+  } else if (device_info->state == kLidarStateInit) {
     level = DiagStatus::WARN;
     error_str = fmt::format("progress: %d%%", device_info->status.progress);
   }

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -764,10 +764,13 @@ void Lddc::onDiagnosticsTimer()
   updater_.force_update();
 }
 
-boost::optional<DeviceInfo*> Lddc::findDeviceInfoByBroadcastcode(const std::string &broadcast_code) {
+boost::optional<DeviceInfo> Lddc::findDeviceInfoByBroadcastcode(const std::string &broadcast_code) {
   for (const auto &connected_lidar : lds_->connected_lidars_) {
     if (connected_lidar.first == broadcast_code) {
-      return connected_lidar.second;
+      if (connected_lidar.second == nullptr) {
+        return {};
+      }
+      return connected_lidar.second->info;
     }
   }
   return {};
@@ -783,11 +786,11 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   if (!device_info) {
     error_str = "disconnected";
-  } else if ((*device_info)->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
+  } else if (device_info->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     TemperatureStatus status = static_cast<TemperatureStatus>(
-      (*device_info)->status.status_code.lidar_error_code.temp_status);
+      device_info->status.status_code.lidar_error_code.temp_status);
     if (status == TemperatureStatus::HighOrLow) {
       level = DiagStatus::WARN;
     } else if (status == TemperatureStatus::ExtremelyHighOrLow) {
@@ -810,11 +813,11 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   if (!device_info) {
     error_str = "disconnected";
-  } else if ((*device_info)->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
+  } else if (device_info->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     VoltageStatus status = static_cast<VoltageStatus>(
-      (*device_info)->status.status_code.lidar_error_code.volt_status);
+      device_info->status.status_code.lidar_error_code.volt_status);
     if (status == VoltageStatus::High) {
       level = DiagStatus::WARN;
     } else if (status == VoltageStatus::ExtremelyHigh) {
@@ -837,11 +840,11 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   if (!device_info) {
     error_str = "disconnected";
-  } else if ((*device_info)->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
+  } else if (device_info->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     MotorStatus status = static_cast<MotorStatus>(
-      (*device_info)->status.status_code.lidar_error_code.motor_status);
+      device_info->status.status_code.lidar_error_code.motor_status);
     if (status == MotorStatus::Warning) {
       level = DiagStatus::WARN;
     } else if (status == MotorStatus::Error) {
@@ -864,11 +867,11 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   if (!device_info) {
     error_str = "disconnected";
-  } else if ((*device_info)->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
+  } else if (device_info->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     DirtyStatus status = static_cast<DirtyStatus>(
-      (*device_info)->status.status_code.lidar_error_code.dirty_warn);
+      device_info->status.status_code.lidar_error_code.dirty_warn);
     if (status == DirtyStatus::DirtyOrBlocked) {
       level = DiagStatus::WARN;
     }
@@ -889,11 +892,11 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   if (!device_info) {
     error_str = "disconnected";
-  } else if ((*device_info)->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
+  } else if (device_info->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     FirmwareStatus status = static_cast<FirmwareStatus>(
-      (*device_info)->status.status_code.lidar_error_code.firmware_err);
+      device_info->status.status_code.lidar_error_code.firmware_err);
     if (status == FirmwareStatus::Abnormal) {
       level = DiagStatus::ERROR;
     }
@@ -914,11 +917,11 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   if (!device_info) {
     error_str = "disconnected";
-  } else if ((*device_info)->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
+  } else if (device_info->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     PPSSignalStatus status = static_cast<PPSSignalStatus>(
-      (*device_info)->status.status_code.lidar_error_code.pps_status);
+      device_info->status.status_code.lidar_error_code.pps_status);
     if (status == PPSSignalStatus::NoSignal) {
       level = DiagStatus::WARN;
     }
@@ -939,11 +942,11 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   if (!device_info) {
     error_str = "disconnected";
-  } else if ((*device_info)->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
+  } else if (device_info->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     ServiceLifeStatus status = static_cast<ServiceLifeStatus>(
-      (*device_info)->status.status_code.lidar_error_code.device_status);
+      device_info->status.status_code.lidar_error_code.device_status);
     if (status == ServiceLifeStatus::Warning) {
       level = DiagStatus::WARN;
     }
@@ -964,11 +967,11 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   if (!device_info) {
     error_str = "disconnected";
-  } else if ((*device_info)->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
+  } else if (device_info->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     FanStatus status = static_cast<FanStatus>(
-      (*device_info)->status.status_code.lidar_error_code.fan_status);
+      device_info->status.status_code.lidar_error_code.fan_status);
     if (status == FanStatus::Warning) {
       level = DiagStatus::WARN;
     }
@@ -988,11 +991,11 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper &stat, con
 
   if (!device_info) {
     error_str = "disconnected";
-  } else if ((*device_info)->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
+  } else if (device_info->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     PTPSignalStatus status = static_cast<PTPSignalStatus>(
-      (*device_info)->status.status_code.lidar_error_code.ptp_status);
+      device_info->status.status_code.lidar_error_code.ptp_status);
     if (status == PTPSignalStatus::NoSignal) {
       level = DiagStatus::WARN;
     }
@@ -1013,11 +1016,11 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper &stat,
 
   if (!device_info) {
     error_str = "disconnected";
-  } else if ((*device_info)->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
+  } else if (device_info->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", device_info->status.progress);
   } else {
     TimeSyncStatus status = static_cast<TimeSyncStatus>(
-      (*device_info)->status.status_code.lidar_error_code.time_sync_status);
+      device_info->status.status_code.lidar_error_code.time_sync_status);
     if (status == TimeSyncStatus::Abnormal) {
       level = DiagStatus::WARN;
     }
@@ -1039,9 +1042,9 @@ void Lddc::checkConnection(diagnostic_updater::DiagnosticStatusWrapper &stat,
   if (!device_info) {
     level = DiagStatus::ERROR;
     error_str = "disconnected";
-  } else if ((*device_info)->state == kLidarStateInit) {
+  } else if (device_info->state == kLidarStateInit) {
     level = DiagStatus::WARN;
-    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
+    error_str = fmt::format("progress: %d%%", device_info->status.progress);
   }
 
   stat.add("broadcast_code", broadcast_code);

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -1142,7 +1142,7 @@ void Lddc::checkConnection(diagnostic_updater::DiagnosticStatusWrapper & stat)
   }
 }
 
-void Lddc::checkConnect(diagnostic_updater::DiagnosticStatusWrapper & stat)
+void Lddc::checkConnection(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   if (lidar_count_ == 0) {
     stat.summary(DiagStatus::WARN, "No LiDARs Connected");
@@ -1169,7 +1169,7 @@ void Lddc::checkConnect(diagnostic_updater::DiagnosticStatusWrapper & stat)
       continue;
     }
 
-    stat.add(broadcast_code, connect_dict_.at(level));
+    stat.add(broadcast_code, connection_dict_.at(level));
     whole_level = std::max(whole_level, level);
   }
 
@@ -1177,7 +1177,7 @@ void Lddc::checkConnect(diagnostic_updater::DiagnosticStatusWrapper & stat)
     stat.summary(DiagStatus::ERROR, error_str);
   }
   else {
-    stat.summary(whole_level, connect_dict_.at(whole_level));
+    stat.summary(whole_level, connection_dict_.at(whole_level));
   }
 }
 }  // namespace livox_ros

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -764,13 +764,13 @@ void Lddc::onDiagnosticsTimer()
   updater_.force_update();
 }
 
-void Lddc::getLidarByBroadcastcode(std::pair<std::string, DeviceInfo *> &lidar,
-                                   const std::string &broadcast_code)
-{
-  for (const auto & connected_lidar : lds_->connected_lidars_) {
-    const std::string connected_broadcast_code = connected_lidar.first;
-    if (connected_broadcast_code == broadcast_code) lidar = connected_lidar;
+boost::optional<DeviceInfo*> Lddc::findDeviceInfoByBroadcastcode(const std::string &broadcast_code) {
+  for (const auto &connected_lidar : lds_->connected_lidars_) {
+    if (connected_lidar.first == broadcast_code) {
+      return connected_lidar.second;
+    }
   }
+  return {};
 }
 
 void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper &stat,
@@ -779,18 +779,15 @@ void Lddc::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper &stat,
   int level = DiagStatus::OK;
   std::string error_str = "OK";
 
-  std::pair<std::string, DeviceInfo*> lidar;
-  getLidarByBroadcastcode(lidar, broadcast_code);
+  const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  const auto & device_info = lidar.second;
-
-  if (device_info == nullptr) {
+  if (*device_info == nullptr) {
     error_str = "disconnected";
-  } else if (device_info->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", device_info->status.progress);
+  } else if ((*device_info)->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
   } else {
     TemperatureStatus status = static_cast<TemperatureStatus>(
-      device_info->status.status_code.lidar_error_code.temp_status);
+      (*device_info)->status.status_code.lidar_error_code.temp_status);
     if (status == TemperatureStatus::HighOrLow) {
       level = DiagStatus::WARN;
     } else if (status == TemperatureStatus::ExtremelyHighOrLow) {
@@ -809,18 +806,15 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper &stat,
   int level = DiagStatus::OK;
   std::string error_str = "OK";
 
-  std::pair<std::string, DeviceInfo*> lidar;
-  getLidarByBroadcastcode(lidar, broadcast_code);
+  const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  const auto & device_info = lidar.second;
-
-  if (device_info == nullptr) {
+  if (*device_info == nullptr) {
     error_str = "disconnected";
-  } else if (device_info->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", device_info->status.progress);
+  } else if ((*device_info)->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
   } else {
     VoltageStatus status = static_cast<VoltageStatus>(
-      device_info->status.status_code.lidar_error_code.volt_status);
+      (*device_info)->status.status_code.lidar_error_code.volt_status);
     if (status == VoltageStatus::High) {
       level = DiagStatus::WARN;
     } else if (status == VoltageStatus::ExtremelyHigh) {
@@ -839,18 +833,15 @@ void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper &stat,
   int level = DiagStatus::OK;
   std::string error_str = "OK";
 
-  std::pair<std::string, DeviceInfo*> lidar;
-  getLidarByBroadcastcode(lidar, broadcast_code);
+  const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  const auto &device_info = lidar.second;
-
-  if (device_info == nullptr) {
+  if (*device_info == nullptr) {
     error_str = "disconnected";
-  } else if (device_info->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", device_info->status.progress);
+  } else if ((*device_info)->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
   } else {
     MotorStatus status = static_cast<MotorStatus>(
-      device_info->status.status_code.lidar_error_code.motor_status);
+      (*device_info)->status.status_code.lidar_error_code.motor_status);
     if (status == MotorStatus::Warning) {
       level = DiagStatus::WARN;
     } else if (status == MotorStatus::Error) {
@@ -869,18 +860,15 @@ void Lddc::checkDirty(diagnostic_updater::DiagnosticStatusWrapper &stat,
   int level = DiagStatus::OK;
   std::string error_str = "OK";
 
-  std::pair<std::string, DeviceInfo*> lidar;
-  getLidarByBroadcastcode(lidar, broadcast_code);
+  const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  const auto & device_info = lidar.second;
-
-  if (device_info == nullptr) {
+  if (*device_info == nullptr) {
     error_str = "disconnected";
-  } else if (device_info->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", device_info->status.progress);
+  } else if ((*device_info)->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
   } else {
     DirtyStatus status = static_cast<DirtyStatus>(
-      device_info->status.status_code.lidar_error_code.dirty_warn);
+      (*device_info)->status.status_code.lidar_error_code.dirty_warn);
     if (status == DirtyStatus::DirtyOrBlocked) {
       level = DiagStatus::WARN;
     }
@@ -897,18 +885,15 @@ void Lddc::checkFirmware(diagnostic_updater::DiagnosticStatusWrapper &stat,
   int level = DiagStatus::OK;
   std::string error_str = "OK";
 
-  std::pair<std::string, DeviceInfo*> lidar;
-  getLidarByBroadcastcode(lidar, broadcast_code);
+  const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  const auto &device_info = lidar.second;
-
-  if (device_info == nullptr) {
+  if (*device_info == nullptr) {
     error_str = "disconnected";
-  } else if (device_info->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", device_info->status.progress);
+  } else if ((*device_info)->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
   } else {
     FirmwareStatus status = static_cast<FirmwareStatus>(
-      device_info->status.status_code.lidar_error_code.firmware_err);
+      (*device_info)->status.status_code.lidar_error_code.firmware_err);
     if (status == FirmwareStatus::Abnormal) {
       level = DiagStatus::ERROR;
     }
@@ -925,18 +910,15 @@ void Lddc::checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper &stat,
   int level = DiagStatus::OK;
   std::string error_str = "OK";
 
-  std::pair<std::string, DeviceInfo*> lidar;
-  getLidarByBroadcastcode(lidar, broadcast_code);
+  const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  const auto &device_info = lidar.second;
-
-  if (device_info == nullptr) {
+  if (*device_info == nullptr) {
     error_str = "disconnected";
-  } else if (device_info->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", device_info->status.progress);
+  } else if ((*device_info)->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
   } else {
     PPSSignalStatus status = static_cast<PPSSignalStatus>(
-      device_info->status.status_code.lidar_error_code.pps_status);
+      (*device_info)->status.status_code.lidar_error_code.pps_status);
     if (status == PPSSignalStatus::NoSignal) {
       level = DiagStatus::WARN;
     }
@@ -953,18 +935,15 @@ void Lddc::checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper &stat,
   int level = DiagStatus::OK;
   std::string error_str = "OK";
 
-  std::pair<std::string, DeviceInfo*> lidar;
-  getLidarByBroadcastcode(lidar, broadcast_code);
+  const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  const auto & device_info = lidar.second;
-
-  if (device_info == nullptr) {
+  if (*device_info == nullptr) {
     error_str = "disconnected";
-  } else if (device_info->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", device_info->status.progress);
+  } else if ((*device_info)->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
   } else {
     ServiceLifeStatus status = static_cast<ServiceLifeStatus>(
-      device_info->status.status_code.lidar_error_code.device_status);
+      (*device_info)->status.status_code.lidar_error_code.device_status);
     if (status == ServiceLifeStatus::Warning) {
       level = DiagStatus::WARN;
     }
@@ -981,18 +960,15 @@ void Lddc::checkFan(diagnostic_updater::DiagnosticStatusWrapper &stat,
   int level = DiagStatus::OK;
   std::string error_str = "OK";
 
-  std::pair<std::string, DeviceInfo*> lidar;
-  getLidarByBroadcastcode(lidar, broadcast_code);
+  const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  const auto & device_info = lidar.second;
-
-  if (device_info == nullptr) {
+  if (*device_info == nullptr) {
     error_str = "disconnected";
-  } else if (device_info->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", device_info->status.progress);
+  } else if ((*device_info)->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
   } else {
     FanStatus status = static_cast<FanStatus>(
-      device_info->status.status_code.lidar_error_code.fan_status);
+      (*device_info)->status.status_code.lidar_error_code.fan_status);
     if (status == FanStatus::Warning) {
       level = DiagStatus::WARN;
     }
@@ -1008,18 +984,15 @@ void Lddc::checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper &stat, con
   int level = DiagStatus::OK;
   std::string error_str = "OK";
 
-  std::pair<std::string, DeviceInfo*> lidar;
-  getLidarByBroadcastcode(lidar, broadcast_code);
+  const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  const auto & device_info = lidar.second;
-
-  if (device_info == nullptr) {
+  if (*device_info == nullptr) {
     error_str = "disconnected";
-  } else if (device_info->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", device_info->status.progress);
+  } else if ((*device_info)->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
   } else {
     PTPSignalStatus status = static_cast<PTPSignalStatus>(
-      device_info->status.status_code.lidar_error_code.ptp_status);
+      (*device_info)->status.status_code.lidar_error_code.ptp_status);
     if (status == PTPSignalStatus::NoSignal) {
       level = DiagStatus::WARN;
     }
@@ -1036,18 +1009,15 @@ void Lddc::checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper &stat,
   int level = DiagStatus::OK;
   std::string error_str = "OK";
 
-  std::pair<std::string, DeviceInfo*> lidar;
-  getLidarByBroadcastcode(lidar, broadcast_code);
+  const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  const auto & device_info = lidar.second;
-
-  if (device_info == nullptr) {
+  if (*device_info == nullptr) {
     error_str = "disconnected";
-  } else if (device_info->state == kLidarStateInit) {
-    error_str = fmt::format("progress: %d%%", device_info->status.progress);
+  } else if ((*device_info)->state == kLidarStateInit) {
+    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
   } else {
     TimeSyncStatus status = static_cast<TimeSyncStatus>(
-      device_info->status.status_code.lidar_error_code.time_sync_status);
+      (*device_info)->status.status_code.lidar_error_code.time_sync_status);
     if (status == TimeSyncStatus::Abnormal) {
       level = DiagStatus::WARN;
     }
@@ -1064,17 +1034,14 @@ void Lddc::checkConnection(diagnostic_updater::DiagnosticStatusWrapper &stat,
   int level = DiagStatus::OK;
   std::string error_str = "OK";
 
-  std::pair<std::string, DeviceInfo*> lidar;
-  getLidarByBroadcastcode(lidar, broadcast_code);
+  const auto device_info = findDeviceInfoByBroadcastcode(broadcast_code);
 
-  const auto & device_info = lidar.second;
-
-  if (device_info == nullptr) {
+  if (*device_info == nullptr) {
     level = DiagStatus::ERROR;
     error_str = "disconnected";
-  } else if (device_info->state == kLidarStateInit) {
+  } else if ((*device_info)->state == kLidarStateInit) {
     level = DiagStatus::WARN;
-    error_str = fmt::format("progress: %d%%", device_info->status.progress);
+    error_str = fmt::format("progress: %d%%", (*device_info)->status.progress);
   }
 
   stat.add(broadcast_code, error_str);

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -704,6 +704,7 @@ void Lddc::initializeDiagnostics()
 
 void Lddc::registerDiagnosticsUpdater(const std::string &broadcast_code)
 {
+  registered_code_set_.insert(broadcast_code);
   if (registered_code_set_.count(broadcast_code) == 0) {
     updater_.add(fmt::format("livox_temperature-{}", broadcast_code),
                  std::bind(&Lddc::checkTemperature, this, std::placeholders::_1,

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -826,8 +826,8 @@ void Lddc::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper &stat,
     error_str = voltage_dict_.at(level);
   }
 
-    stat.add("broadcast_code", broadcast_code);
-    stat.summary(level, error_str);
+  stat.add("broadcast_code", broadcast_code);
+  stat.summary(level, error_str);
 }
 
 void Lddc::checkMotor(diagnostic_updater::DiagnosticStatusWrapper &stat,

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -705,31 +705,31 @@ void Lddc::initializeDiagnostics()
 void Lddc::registerDiagnosticsUpdater(const std::string &broadcast_code)
 {
   updater_.add(
-      fmt::format("livox_temperature_{}", broadcast_code),
+      fmt::format("livox_temperature-{}", broadcast_code),
       std::bind(
           &Lddc::checkTemperature, this, std::placeholders::_1,
           broadcast_code));
 
   updater_.add(
-      fmt::format("livox_internal_voltage_{}", broadcast_code),
+      fmt::format("livox_internal_voltage-{}", broadcast_code),
       std::bind(
           &Lddc::checkVoltage, this, std::placeholders::_1,
           broadcast_code));
 
   updater_.add(
-      fmt::format("livox_motor_status_{}", broadcast_code),
+      fmt::format("livox_motor_status-{}", broadcast_code),
       std::bind(
           &Lddc::checkMotor, this, std::placeholders::_1,
           broadcast_code));
 
   updater_.add(
-      fmt::format("livox_optical_window_{}", broadcast_code),
+      fmt::format("livox_optical_window-{}", broadcast_code),
       std::bind(
           &Lddc::checkDirty, this, std::placeholders::_1,
           broadcast_code));
 
   updater_.add(
-      fmt::format("livox_firmware_status_{}", broadcast_code),
+      fmt::format("livox_firmware_status-{}", broadcast_code),
       std::bind(
           &Lddc::checkFirmware, this, std::placeholders::_1,
           broadcast_code));
@@ -737,32 +737,32 @@ void Lddc::registerDiagnosticsUpdater(const std::string &broadcast_code)
   if (check_pps_signal_)
   {
     updater_.add(
-        fmt::format("livox_pps_signal_{}", broadcast_code),
+        fmt::format("livox_pps_signal-{}", broadcast_code),
         std::bind(
             &Lddc::checkPPSSignal, this, std::placeholders::_1,
             broadcast_code));
   }
 
   updater_.add(
-      fmt::format("livox_service_life_{}", broadcast_code),
+      fmt::format("livox_service_life-{}", broadcast_code),
       std::bind(
           &Lddc::checkServiceLife, this, std::placeholders::_1,
           broadcast_code));
 
   updater_.add(
-      fmt::format("livox_fan_status_{}", broadcast_code),
+      fmt::format("livox_fan_status-{}", broadcast_code),
       std::bind(
           &Lddc::checkFan, this, std::placeholders::_1,
           broadcast_code));
 
   updater_.add(
-      fmt::format("livox_time_sync_{}", broadcast_code),
+      fmt::format("livox_time_sync-{}", broadcast_code),
       std::bind(
           &Lddc::checkTimeSync, this, std::placeholders::_1,
           broadcast_code));
 
   updater_.add(
-      fmt::format("livox_connection_{}", broadcast_code),
+      fmt::format("livox_connection-{}", broadcast_code),
       std::bind(
           &Lddc::checkConnection, this, std::placeholders::_1,
           broadcast_code));

--- a/livox_ros2_driver/livox_ros2_driver/lddc.h
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.h
@@ -164,6 +164,9 @@ private:
   const std::map<int, const char *> time_sync_dict_ = {
     {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "System time synchronization is abnormal"}, {DiagStatus::ERROR, "unused"}};
 
+  const std::map<int, const char *> connect_dict_ = {
+    {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "disconnected"}, {DiagStatus::ERROR, "disconnected"}};
+
 };
 
 }  // namespace livox_ros

--- a/livox_ros2_driver/livox_ros2_driver/lddc.h
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.h
@@ -164,9 +164,6 @@ private:
   const std::map<int, const char *> time_sync_dict_ = {
     {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "System time synchronization is abnormal"}, {DiagStatus::ERROR, "unused"}};
 
-  const std::map<int, const char *> connection_dict_ = {
-    {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "disconnected"}, {DiagStatus::ERROR, "disconnected"}};
-
 };
 
 }  // namespace livox_ros

--- a/livox_ros2_driver/livox_ros2_driver/lddc.h
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.h
@@ -137,7 +137,7 @@ private:
   diagnostic_updater::Updater updater_;
   uint8_t lidar_count_;
   uint8_t connected_lidar_count_ = 0;
-  std::multiset<std::string> registered_code_set_;
+  std::set<std::string> registered_code_set_;
 
   const std::map<int, const char *> temperature_dict_ = {
     {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "High or Low"}, {DiagStatus::ERROR, "Extremely High or Extremely Low"}};

--- a/livox_ros2_driver/livox_ros2_driver/lddc.h
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.h
@@ -137,6 +137,7 @@ private:
   diagnostic_updater::Updater updater_;
   uint8_t lidar_count_;
   uint8_t connected_lidar_count_ = 0;
+  std::multiset<std::string> registered_code_set_;
 
   const std::map<int, const char *> temperature_dict_ = {
     {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "High or Low"}, {DiagStatus::ERROR, "Extremely High or Extremely Low"}};

--- a/livox_ros2_driver/livox_ros2_driver/lddc.h
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.h
@@ -115,7 +115,7 @@ private:
   void checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
   void checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
   void checkConnection(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
-  void getLidarByBroadcastcode(std::pair<std::string, DeviceInfo*> & lidar, const std::string & broadcast_code);
+  boost::optional<DeviceInfo*> findDeviceInfoByBroadcastcode(const std::string &broadcast_code);
 
   uint8_t transfer_format_;
   uint8_t use_multi_topic_;

--- a/livox_ros2_driver/livox_ros2_driver/lddc.h
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.h
@@ -103,6 +103,7 @@ private:
       uint32_t point_interval, uint32_t echo_num);
 
   void onDiagnosticsTimer();
+  void registerDiagnosticsUpdater(const std::string & broadcast_code);
   void checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
   void checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
   void checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);

--- a/livox_ros2_driver/livox_ros2_driver/lddc.h
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.h
@@ -136,7 +136,6 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
   diagnostic_updater::Updater updater_;
   uint8_t lidar_count_;
-  uint8_t connected_lidar_count_ = 0;
   std::set<std::string> registered_code_set_;
 
   const std::map<int, const char *> temperature_dict_ = {

--- a/livox_ros2_driver/livox_ros2_driver/lddc.h
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.h
@@ -103,17 +103,18 @@ private:
       uint32_t point_interval, uint32_t echo_num);
 
   void onDiagnosticsTimer();
-  void checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat);
-  void checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat);
-  void checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat);
-  void checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat);
-  void checkFirmware(diagnostic_updater::DiagnosticStatusWrapper & stat);
-  void checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat);
-  void checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat);
-  void checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat);
-  void checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat);
-  void checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat);
-  void checkConnection(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  void checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
+  void checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
+  void checkMotor(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
+  void checkDirty(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
+  void checkFirmware(diagnostic_updater::DiagnosticStatusWrapper &stat, const std::string &broadcast_code);
+  void checkPPSSignal(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
+  void checkServiceLife(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
+  void checkFan(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
+  void checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
+  void checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
+  void checkConnection(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
+  void getLidarByBroadcastcode(std::pair<std::string, DeviceInfo*> & lidar, const std::string & broadcast_code);
 
   uint8_t transfer_format_;
   uint8_t use_multi_topic_;
@@ -122,6 +123,7 @@ private:
   double publish_frq_;
   uint32_t publish_period_ns_;
   std::string frame_id_;
+  bool check_pps_signal_;
 
   std::shared_ptr<rclcpp::PublisherBase>private_pub_[kMaxSourceLidar];
   std::shared_ptr<rclcpp::PublisherBase>global_pub_;
@@ -133,6 +135,7 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
   diagnostic_updater::Updater updater_;
   uint8_t lidar_count_;
+  uint8_t connected_lidar_count_ = 0;
 
   const std::map<int, const char *> temperature_dict_ = {
     {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "High or Low"}, {DiagStatus::ERROR, "Extremely High or Extremely Low"}};

--- a/livox_ros2_driver/livox_ros2_driver/lddc.h
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.h
@@ -115,7 +115,7 @@ private:
   void checkPTPSignal(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
   void checkTimeSync(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
   void checkConnection(diagnostic_updater::DiagnosticStatusWrapper & stat, const std::string & broadcast_code);
-  boost::optional<DeviceInfo*> findDeviceInfoByBroadcastcode(const std::string &broadcast_code);
+  boost::optional<DeviceInfo> findDeviceInfoByBroadcastcode(const std::string &broadcast_code);
 
   uint8_t transfer_format_;
   uint8_t use_multi_topic_;

--- a/livox_ros2_driver/livox_ros2_driver/lddc.h
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.h
@@ -164,7 +164,7 @@ private:
   const std::map<int, const char *> time_sync_dict_ = {
     {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "System time synchronization is abnormal"}, {DiagStatus::ERROR, "unused"}};
 
-  const std::map<int, const char *> connect_dict_ = {
+  const std::map<int, const char *> connection_dict_ = {
     {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "disconnected"}, {DiagStatus::ERROR, "disconnected"}};
 
 };

--- a/livox_ros2_driver/livox_ros2_driver/lds.h
+++ b/livox_ros2_driver/livox_ros2_driver/lds.h
@@ -499,7 +499,7 @@ class Lds {
   uint8_t lidar_count_;                 /**< Lidar access handle. */
   LidarDevice lidars_[kMaxSourceLidar]; /**< The index is the handle */
   Semaphore semaphore_;
-  std::map<std::string, DeviceInfo*> connected_lidars_;
+  std::map<std::string, LidarDevice*> connected_lidars_;
 
  protected:
   uint32_t buffer_time_ms_; /**< Buffer time before data in queue is read */

--- a/livox_ros2_driver/livox_ros2_driver/lds_lidar.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lds_lidar.cpp
@@ -244,11 +244,11 @@ void LdsLidar::OnDeviceChange(const DeviceInfo *info, DeviceEvent type) {
     if (p_lidar->connect_state == kConnectStateOff) {
       p_lidar->connect_state = kConnectStateOn;
       p_lidar->info = *info;
-      g_lds_ldiar->connected_lidars_[p_lidar->info.broadcast_code] = &p_lidar->info;
+      g_lds_ldiar->connected_lidars_[p_lidar->info.broadcast_code] = p_lidar;
     }
   } else if (type == kEventDisconnect) {
     printf("Lidar[%s] disconnect!\n", info->broadcast_code);
-    g_lds_ldiar->connected_lidars_[p_lidar->info.broadcast_code] = nullptr;
+    g_lds_ldiar->connected_lidars_.erase(p_lidar->info.broadcast_code);
     ResetLidar(p_lidar, kSourceRawLidar);
   } else if (type == kEventStateChange) {
     p_lidar->info = *info;


### PR DESCRIPTION
With this PR, we can identify the error device on FMS.

The final version of
- FMS display
![livox_fms_error](https://user-images.githubusercontent.com/39142679/120578321-945d9e80-c460-11eb-98b3-a1d969703f92.png)
- runtimte_monitor display
![livox_runtime_monitor](https://user-images.githubusercontent.com/39142679/120578434-c4a53d00-c460-11eb-8cf1-20595a1a8274.png)
