### PR TITLE
Add cancle_heartbeat_timeout (#8)

### DIFF
--- a/livox_sdk_vendor/CMakeLists.txt
+++ b/livox_sdk_vendor/CMakeLists.txt
@@ -5,7 +5,7 @@ project(livox_sdk_vendor)
 find_package(ament_cmake REQUIRED)
 
 macro(build_livox_sdk)
-  set(livox_sdk_REV "v2.3.0")
+  set(livox_sdk_REV "cancle_heartbeat_timeout")
   set(extra_cmake_args)
 
   get_property(multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
@@ -15,7 +15,7 @@ macro(build_livox_sdk)
 
   include(ExternalProject)
   externalproject_add(livox-sdk-${livox_sdk_REV}
-    GIT_REPOSITORY https://github.com/Livox-SDK/Livox-SDK.git
+    GIT_REPOSITORY https://github.com/tier4/Livox-SDK.git
     GIT_TAG ${livox_sdk_REV}
     GIT_SHALLOW OFF
     TIMEOUT 60


### PR DESCRIPTION
cherry-pick https://github.com/tier4/livox_ros2_driver/pull/8 because it is reverted in https://github.com/tier4/livox_ros2_driver/pull/9

* Add cancle_heartbeat_timeout

Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

* Use tier4 forked Livox-sdk

Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>